### PR TITLE
feat : 팔로우 페이지 사용자 검색 기능 추가

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -1,6 +1,13 @@
 import { RouterProvider } from '@tanstack/react-router';
 import { router } from '@/routes/Router';
+import { ModalProvider } from '@/contexts/ModalContext';
+import ModalRenderer from '@/components/common/ModalRenderer';
 
 export default function App() {
-    return <RouterProvider router={router} />;
+    return (
+        <ModalProvider>
+            <RouterProvider router={router} />
+            <ModalRenderer />
+        </ModalProvider>
+    );
 }

--- a/src/components/common/ModalRenderer.jsx
+++ b/src/components/common/ModalRenderer.jsx
@@ -1,11 +1,11 @@
 import { useModal } from '@/contexts/ModalContext';
-import FollowerPanel from '@/features/followingList/components/FollowerPanel';
+import UserSearchModal from '@/features/userSearch/componenets/UserSearchModal';
 
 const ModalRenderer = () => {
   const { modalName, modalProps, hideModal } = useModal();
 
-  if (modalName === 'follower') {
-    return <FollowerPanel {...modalProps} onClose={hideModal} />;
+  if (modalName === 'userSearch') {
+    return <UserSearchModal {...modalProps} onClose={hideModal} />;
   }
 
   return null;

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,3 +1,18 @@
+import { useLocation } from '@tanstack/react-router';
+
 export default function Layout({ children }) {
-    return <div style={{ margin: '0 120px' }}>{children}</div>;
+    const location = useLocation();
+    
+    //check :  FollowerPage에서 margin 뺐습니다.
+    const isFollowerPage = location.pathname === '/follower';
+    
+    return (
+        <div style={{ 
+            margin: isFollowerPage ? '0' : '0 120px',
+            height: isFollowerPage ? 'calc(100vh - 50px)' : '100vh',
+            overflow: 'hidden'
+        }}>
+            {children}
+        </div>
+    );
 }

--- a/src/features/followingList/components/FollowerSidebar.jsx
+++ b/src/features/followingList/components/FollowerSidebar.jsx
@@ -24,7 +24,7 @@ const FollowerSidebar = ({ followers }) => {
       {/* 프로필 리스트 영역 */}
       <div className={styles.profileList}>
         {filteredFollowers.map((f) => (
-          <FollowerProfileBox key={f.followsId} follower={f} />
+          <FollowerProfileBox key={f.followingId} follower={f} />
         ))}
       </div>
     </div>

--- a/src/features/followingList/styles/followerSidebar.module.css
+++ b/src/features/followingList/styles/followerSidebar.module.css
@@ -1,12 +1,11 @@
 .sidebarContainer {
-  width: 341px;
+  width: 280px;
   height: 100%;
   background: #fff;
-  border-right: 1px solid #757575;
+  border-right: 1px solid #e0e0e0;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  margin-left: -120px;  /*TODO : 레이아웃 수정하면서 수정 예정입니다.*/
 }
 
 .headerArea {

--- a/src/features/userSearch/api/userSearchApi.js
+++ b/src/features/userSearch/api/userSearchApi.js
@@ -1,0 +1,26 @@
+const url = import.meta.env.VITE_URL;
+
+export async function searchUsers(keyword) {
+    try {
+        const response = await fetch(
+            `${url}/follows/search?nickname=${encodeURIComponent(keyword)}`,
+            {
+                method: 'GET',
+                headers: {
+                    'accept': '*/*',
+                    'Content-Type': 'application/json',
+                }
+            }
+        );
+        
+        if (!response.ok) {
+            throw new Error(`사용자 검색 오류: ${response.status}`);
+        }
+        
+        const data = await response.json();
+        return data;
+    } catch (error) {
+        console.error('API 호출 오류:', error);
+        throw new Error('사용자 검색 중 오류가 발생했습니다.');
+    }
+}

--- a/src/features/userSearch/componenets/UserSearchModal.jsx
+++ b/src/features/userSearch/componenets/UserSearchModal.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { useUserSearch } from '../hooks/useUserSearch';
+import styles from '../styles/userSearchModal.module.css';
+import FollowerProfileBox from '../../followingList/components/FollowerProfileBox';
+import { useModal } from '../../../contexts/ModalContext';
+
+const UserSearchModal = ({ onClose }) => {
+  const { query, setQuery, results, loading, error } = useUserSearch();
+  const handleClose = onClose;
+
+  return ReactDOM.createPortal(
+    <div className={styles.overlay} onClick={handleClose}>
+      <div className={styles.modal} onClick={e => e.stopPropagation()}>
+        <h2 className={styles.title}>사용자 검색</h2>
+        <div className={styles.searchContainer}>
+          <input
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="검색"
+            className={styles.searchInput}
+          />
+        </div>
+        <div className={styles.list}>
+          {loading && <p className={styles.loadingText}>로딩 중...</p>}
+          {error && <p className={styles.errorText}>오류: {error}</p>}
+          {!loading && !error && results.map(user => (
+            <div key={user.userId} className={styles.row}>
+              <div className={styles.userInfo}>
+                <div className={styles.profileImage}>
+                  <img 
+                    src={user.profile || '/public/account_circle.png'} 
+                    alt={user.nickname}
+                    onError={(e) => {
+                      e.target.src = '/public/account_circle.png';
+                    }}
+                  />
+                </div>
+                <div className={styles.userDetails}>
+                  <div className={styles.nickname}>{user.nickname}</div>
+                  <div className={styles.email}>{user.email || '이메일 없음'}</div>
+                </div>
+              </div>
+              <button className={styles.addBtn}>＋</button>
+            </div>
+          ))}
+          {!loading && !error && !results.length && query && <p className={styles.noResults}>검색 결과가 없습니다.</p>}
+        </div>
+        <button className={styles.closeBtn} onClick={handleClose}>×</button>
+      </div>
+    </div>,
+    document.body
+  );
+};
+
+export default UserSearchModal;

--- a/src/features/userSearch/hooks/useUserSearch.js
+++ b/src/features/userSearch/hooks/useUserSearch.js
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { searchUsers } from '../api/userSearchApi';
+
+export function useUserSearch(debounceTime = 300) {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        if (!query.trim()) {
+            setResults([]);
+            setError(null);
+            return;
+        }
+        
+        setLoading(true);
+        setError(null);
+        
+        const handler = setTimeout(async () => {
+            try {
+                const users = await searchUsers(query);
+                setResults(users || []);
+            } catch (error) {
+                console.error('사용자 검색 오류:', error);
+                setError(error.message);
+                setResults([]);
+            } finally {
+                setLoading(false);
+            }
+        }, debounceTime);
+        
+        return () => clearTimeout(handler);
+    }, [query, debounceTime]);
+
+    return { query, setQuery, results, loading, error };
+}

--- a/src/features/userSearch/styles/userSearchModal.module.css
+++ b/src/features/userSearch/styles/userSearchModal.module.css
@@ -1,0 +1,161 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  padding: 32px;
+  width: 600px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+}
+.title {
+  margin-bottom: 24px;
+  text-align: left;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #333;
+}
+
+.searchInput {
+  width: 100%;
+  padding: 12px 16px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 1rem;
+  margin-bottom: 20px;
+  position: relative;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.searchContainer {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+
+.list {
+  margin-top: 0;
+  overflow-y: auto;
+  flex: 1;
+  max-height: 400px;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.addBtn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #007bff;
+  font-weight: bold;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.addBtn:hover {
+  background-color: rgba(0, 123, 255, 0.1);
+}
+
+.userInfo {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.profileImage {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  overflow: hidden;
+  margin-right: 12px;
+  flex-shrink: 0;
+}
+
+.profileImage img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.userDetails {
+  flex: 1;
+  min-width: 0;
+}
+
+.nickname {
+  font-weight: 500;
+  color: #333;
+  margin-bottom: 2px;
+  font-size: 14px;
+}
+
+.email {
+  color: #666;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.loadingText, .noResults, .errorText {
+  text-align: center;
+  padding: 20px;
+  font-size: 14px;
+}
+
+.loadingText, .noResults {
+  color: #666;
+}
+
+.errorText {
+  color: #dc3545;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  border-radius: 4px;
+  margin: 10px 0;
+}
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 28px;
+  cursor: pointer;
+  color: #666;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+}
+
+.closeBtn:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}

--- a/src/pages/FollowerPage/FollowerPage.jsx
+++ b/src/pages/FollowerPage/FollowerPage.jsx
@@ -1,25 +1,40 @@
 import React from "react";
-import styles from './FollowerPage.module.css';
+import styles from "./FollowerPage.module.css";
 import FollowerSidebar from "@/features/followingList/components/FollowerSidebar";
 import { useFetchFollowingList } from "@/features/followingList/hooks/useFetchFollowingList";
-
+import { useModal } from "@/contexts/ModalContext";
 
 const FollowerPage = () => {
-    const {data : followers, loading, error} = useFetchFollowingList({ userId : 5}); //TODO : 실제 userId 변경 예정
+  const { data: followers, loading, error } = useFetchFollowingList({ userId: 5 });
+  const { showModal } = useModal();
 
-    if (loading) return <div>로딩 중...</div>;
-    if (error) return <div>에러 발생 : follower Page</div>;
+  if (loading) return <div>로딩 중...</div>;
+  if (error)   return <div>에러 발생 : follower Page</div>;
 
-
-    return (
+  return (
     <div className={styles.container}>
-      <FollowerSidebar followers={followers} />
-      <div className={styles.contentArea}>팔로워 콘텐츠 표시 예정.</div>
+      <div className={styles.main}>
+        
+        <aside className={styles.sidebar}>
+          <FollowerSidebar followers={followers} />
+        </aside>
+
+        <div className={styles.contentWrapper}>
+          <div className={styles.contentHeader}>
+            <button
+              className={styles.searchTrigger}
+              onClick={() => showModal("userSearch")}
+            >
+              사용자 검색
+            </button>
+          </div>
+          <div className={styles.contentArea}>
+            팔로워 콘텐츠 표시 예정.
+          </div>
+        </div>
+      </div>
     </div>
   );
-
-
-
 };
 
 export default FollowerPage;

--- a/src/pages/FollowerPage/FollowerPage.module.css
+++ b/src/pages/FollowerPage/FollowerPage.module.css
@@ -1,10 +1,72 @@
 .container {
+  height: calc(100vh - 50px);
+  width: 100%;
+  overflow: hidden;
+  background: #f8f9fa;
+}
+
+.main {
   display: flex;
-  height: calc(100vh - 81px); /* 헤더 제외 */
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+.sidebar {
+  width: 280px;
+  min-width: 280px;
+  border-right: 1px solid #e0e0e0;
+  overflow-y: auto;
+  background: #fff;
+  position: relative;
+  z-index: 1;
+  box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
+}
+
+.contentWrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: #f8f9fa;
+  border-left: 1px solid #e0e0e0;
+}
+
+.contentHeader {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #eee;
+}
+
+.searchTrigger {
+  background: #757575;
+  border: none;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: white;
+  padding: 8px 16px;
+  border-radius: 6px;
+  transition: all 0.2s;
+  font-weight: 500;
+}
+
+.searchTrigger:hover {
+  background: #757575;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(36, 36, 36, 0.3);
 }
 
 .contentArea {
   flex: 1;
-  padding: 2rem;
-  background-color: #fff;
+  padding: 24px;
+  overflow-y: auto;     /* 콘텐츠 스크롤 독립 */
+}
+
+/* 반응형 예시 */
+@media (max-width: 768px) {
+  .sidebar {
+    width: 200px;
+  }
 }


### PR DESCRIPTION
# 팔로우 페이지 사용자 검색 기능 모달 추가
---
## layout
- 전역 레이아웃에서 margin 값 -120px이 팔로우 리스트를 가리는 현상 수정.
- margin 값 -120px을 팔로우 페이지에서는 적용되지 않도록 예외 처리 -> 레이아웃 수정하면서 바꿀 예정.

## FollowerPage 수정
- css 레이아웃 부분 -> 사이드바, 메인 콘텐츠, 헤더로 나눔.
- 헤더에 사용자 검색 버튼 추가.

## 사용자 검색 모달 추가
- 팔로우 페이지에서 '사용자 검색 버튼' 클릭시 모달 보이게 추가.
- 추후 모달 부분 컴포넌트 단위로 나눌 예정.
