### PR TITLE
feat : 헤더 이용가이드/메인 설문 버튼 추가, API 스펙(targetUserId) 반영, 폴더→상세 쿼리 경량화 및 드롭다운 폴백, 헤더 문구 수정

### DIFF
--- a/src/features/create/components/LinkAddModal.jsx
+++ b/src/features/create/components/LinkAddModal.jsx
@@ -40,9 +40,10 @@ export default function LinkAddModal({ onClose, onSubmit, folders = [] }) {
         onClose();
     };
 
-    // 폴더를 타입별로 분류
-    const ownFolders = folders.filter((folder) => folder.type === 'own');
-    const sharedFolders = folders.filter((folder) => folder.type === 'shared');
+    // 폴더를 타입별로 분류 (type 정보가 없으면 전체를 단일 리스트로 표시)
+    const hasType = folders.some((f) => f && typeof f === 'object' && 'type' in f);
+    const ownFolders = hasType ? folders.filter((folder) => folder.type === 'own') : folders;
+    const sharedFolders = hasType ? folders.filter((folder) => folder.type === 'shared') : [];
 
     return (
         <div className="LinkAddModalBackdrop" onClick={handleLinkCancel}>

--- a/src/features/folderDetail/api/folderDetailApi.js
+++ b/src/features/folderDetail/api/folderDetailApi.js
@@ -1,11 +1,10 @@
-
 import api from '@/utils/axiosConfig';
 
 const url = import.meta.env.VITE_URL;
 
 // 폴더 상세 정보 및 전체 링크 목록 조회
-export const getFolderDetail = async (folderId) => {
-    const res = await api.get(`${url}/folders/me/folders/${folderId}/links`);
+export const getFolderDetail = async (folderId, targetUserId) => {
+    const res = await api.get(`${url}/folders/users/folders/${folderId}/links/${targetUserId}`);
     console.log('폴더 상세 정보 및 링크 목록:', res.data);
     return res.data;
 };

--- a/src/features/folderDetail/hooks/useFolderDetail.js
+++ b/src/features/folderDetail/hooks/useFolderDetail.js
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
 import { getFolderDetail } from '../api/folderDetailApi';
+import { useAuthStore } from '@/stores/authStore';
 
 export default function useFolderDetail(folderId) {
     const [folderInfo, setFolderInfo] = useState(null);
     const [links, setLinks] = useState([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
+    const { user } = useAuthStore();
+    const userId = user?.userId;
 
     // 폴더 상세 정보 및 링크 목록 조회
     const fetchFolderDetail = async () => {
@@ -16,7 +19,7 @@ export default function useFolderDetail(folderId) {
 
         try {
             // 하나의 API로 폴더 정보와 링크 목록을 모두 가져옴
-            const data = await getFolderDetail(folderId);
+            const data = await getFolderDetail(folderId, userId);
 
             // 폴더 정보 분리
             const { links: linksList, ...folderData } = data;

--- a/src/features/header/components/logo.jsx
+++ b/src/features/header/components/logo.jsx
@@ -3,13 +3,25 @@ import { useNavigate } from '@tanstack/react-router';
 
 export default function Logo() {
     const navigate = useNavigate();
+    const userGuideUrl = import.meta.env.VITE_USER_GUIDE_URL;
 
     return (
-        <div className="Logo" onClick={() => navigate({ to: '/' })}>
-            <img src="/Kkrap_logo.png" alt="크크랩 로고" className="LogoImage" />
-            <span className="LogoText1">크</span>
-            <span className="LogoText2">크</span>
-            <span className="LogoText1">랩</span>
-        </div>
+        <>
+            <div className="HeaderLogo" onClick={() => navigate({ to: '/' })}>
+                <img src="/Kkrap_logo.png" alt="크크랩 로고" className="LogoImage" />
+                <span className="LogoText1">크</span>
+                <span className="LogoText2">크</span>
+                <span className="LogoText1">랩</span>
+                <a
+                    className="UserGuideButton"
+                    href={userGuideUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    ?
+                </a>
+            </div>
+        </>
     );
 }

--- a/src/features/header/styles/Header.css
+++ b/src/features/header/styles/Header.css
@@ -9,14 +9,15 @@
     top: 0;
     left: 0;
     right: 0;
-    z-index: 1000; /* 검색 컴포넌트보다 높은 z-index */
+    z-index: 1000;
 }
 
-.Logo {
+.HeaderLogo {
     margin-left: 120px;
     display: flex;
     align-items: center;
     justify-self: start;
+    cursor: pointer;
 }
 
 .LogoImage {
@@ -33,6 +34,30 @@
     font-weight: bold;
     font-size: 16px;
     color: #5ab7fc;
+}
+
+.UserGuideButton {
+    margin-left: 16px;
+    width: 22px;
+    height: 22px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #cfd8dc;
+    border-radius: 50%;
+    background: #fff;
+    color: #546e7a;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 14px;
+}
+.UserGuideButton:hover {
+    background: #f5f8fa;
+    border-color: #b0bec5;
+}
+.UserGuideButton:active {
+    background: #e3f2fd;
+    border-color: #90a4ae;
 }
 
 .NavMenu {

--- a/src/features/main/components/ExploreSharedSection.jsx
+++ b/src/features/main/components/ExploreSharedSection.jsx
@@ -101,7 +101,6 @@ export default function ExploreSharedSection() {
                     const displayName = folder.nickname ?? '사용자';
                     const avatarSrc = folder.profileImage ?? '/Kkrap_logo.png';
                     const userFolderCreateTime = folder.createTime;
-                    console.log('userFolderCreateTime', userFolderCreateTime);
 
                     const links =
                         folder.thumbnailUrl || folder.faviconUrl

--- a/src/features/main/styles/MyFoldersSection.css
+++ b/src/features/main/styles/MyFoldersSection.css
@@ -151,7 +151,6 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    padding-top: 20px;
 }
 
 .SectionTitle {

--- a/src/features/profile/styles/ProfileForm.css
+++ b/src/features/profile/styles/ProfileForm.css
@@ -44,7 +44,7 @@ textarea {
 
 .CheckBtn {
     padding: 0 14px;
-    background-color: #4baef3;
+    background-color: #5ab7fc;
     color: #fff;
     border: none;
     border-radius: 6px;

--- a/src/features/storage/api/myFolderApi.js
+++ b/src/features/storage/api/myFolderApi.js
@@ -3,8 +3,8 @@ import api from '@/utils/axiosConfig';
 const url = import.meta.env.VITE_URL;
 
 //폴더 조회(내 폴더, 공유 폴더)
-export const getMyFolders = async () => {
-    const res = await api.get(`${url}/folders/users/folders/thumbnails/me`);
+export const getMyFolders = async (targetUserId) => {
+    const res = await api.get(`${url}/folders/users/folders/thumbnails/${targetUserId}`);
     console.log('폴더 조회 데이터', res.data);
     return res.data;
 };

--- a/src/features/storage/components/MyFolderCard.jsx
+++ b/src/features/storage/components/MyFolderCard.jsx
@@ -37,8 +37,14 @@ const MyFolderCard = ({ folder, onDelete, onEdit, onPermission, defaultFolderId,
             return;
         }
 
-        // 전체 폴더 정보를 JSON으로 인코딩하여 URL 파라미터로 전달
-        const allFoldersParam = allFolders ? encodeURIComponent(JSON.stringify(allFolders)) : '';
+        // 상세 페이지에서 필요한 최소 정보(폴더ID, 폴더명)만 전달
+        const allFoldersParam = allFolders
+            ? encodeURIComponent(
+                  JSON.stringify(
+                      allFolders.map((f) => ({ folderId: f.folderId, folderName: f.folderName, type: f.type }))
+                  )
+              )
+            : '';
         const defaultFolderIdParam = defaultFolderId ? `&defaultFolderId=${defaultFolderId}` : '';
 
         const url = `/storage/${folderId}?allFolders=${allFoldersParam}${defaultFolderIdParam}`;

--- a/src/pages/MainPage/MainPage.css
+++ b/src/pages/MainPage/MainPage.css
@@ -32,3 +32,41 @@
     width: 100vw;
     margin-left: calc(49.66% - 50vw);
 }
+
+.MainPageHeader {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    padding-top: 20px;
+}
+
+.MainPageHeaderButton {
+    display: flex;
+    width: 180px;
+    height: 32px;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid #5ab7fc;
+    border-radius: 12px;
+    background-color: #5ab7fc;
+    color: #ffffff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    transition:
+        background-color 0.2s ease,
+        border-color 0.2s ease,
+        color 0.2s ease;
+}
+
+.MainPageHeaderButton:hover {
+    background-color: #3aa3f6;
+    border-color: #3aa3f6;
+}
+
+.MainPageHeaderButton:active {
+    background-color: #1e88e5;
+    border-color: #1e88e5;
+}

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -5,8 +5,19 @@ import './MainPage.css';
 import ExploreSharedSection from '@/features/main/components/ExploreSharedSection';
 
 function MainPage() {
+    const surveyUrl = import.meta.env.VITE_SURVEY_URL;
+
+    const handleSurveyClick = () => {
+        window.open(surveyUrl, '_blank');
+    };
+
     return (
         <div className="MainPage">
+            <div className="MainPageHeader">
+                <button className="MainPageHeaderButton" onClick={handleSurveyClick}>
+                    설문조사하고 커피 받기
+                </button>
+            </div>
             <MyFoldersSection />
             <div className="MainPageSectionDivider"></div>
             <ExploreSharedSection />


### PR DESCRIPTION
### 완료 사항
- 상단 헤더 팔로워 팔로우로 변경
- 크크랩 로고 옆에 이용가이드 버튼 추가
- 메인페이지 최상단 설문조사 버튼 추가
    이용가이드, 설문조사 url은 env에 추가
- api 변경에 따라 코드 수정
- 폴더페이지 → 상세폴더 페이지로 넘어갈 때 url쿼리 파라미터가 너무 길어서 새로고침 시 오류 수정
    링크 데이터 전체를 다 보내는 게 아닌 필요한 folderId, folderName, type만 쿼리 파라미터로 주도록 변경
