### PR TITLE
feat : 공유폴더 썸네일 4개 보기 변경, 메인 페이지 카드 디자인 4열까지 보이게 기능 추가

### DIFF
--- a/src/features/main/styles/ExploreSharedSection.css
+++ b/src/features/main/styles/ExploreSharedSection.css
@@ -7,18 +7,29 @@
 }
 
 /* 그리드 */
-.ExploreGrid {
+/* .ExploreGrid {
     display: grid;
     gap: 40px 24px;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     margin-top: 24px;
+} */
+ .ExploreGrid {
+    display: grid;
+    gap: 40px 32px;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    margin-top: 24px;
+
+    max-width: calc(4 * 320px + 3 * 24px); /* 카드 4개 + 간격 3개 */
+    margin-left: auto;
+    margin-right: auto;
 }
 
-/*카드 */
+/* 카드 */
 .ExploreCard {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    max-width: 320px;
 }
 
 .ExploreUser {

--- a/src/features/storage/components/MyFolderCard.jsx
+++ b/src/features/storage/components/MyFolderCard.jsx
@@ -5,8 +5,8 @@ import '@/features/storage/styles/MyFolderCard.css';
 
 const MyFolderCard = ({ folder, onDelete, onEdit, onPermission, allFolders, showMenu = true, showLockIcon = false }) => {
 
-    const { folderId, folderName, folderDescription, links, defaultFolder, scrapCount, viewCount, visible } = folder;
-
+    const { folderId, folderName, folderDescription, links, defaultFolder, scrapCount, viewCount, visible, share } = folder;
+    console.log("째2 : ", links)
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const navigate = useNavigate();
     const cardRef = useRef(null);
@@ -57,7 +57,7 @@ const MyFolderCard = ({ folder, onDelete, onEdit, onPermission, allFolders, show
         <div className="MyFolderCard" ref={cardRef} onClick={handleFolderClick}>
             {/* 상단 이미지 영역 */}
             <div className="MyFolderImageContainer">
-                {defaultFolder ? (
+                {share ? (
                     <div className="MultiThumbnailGrid">
                         {(links || []).map((link, idx) => (
                             <img

--- a/src/pages/storagePage/StoragePage.jsx
+++ b/src/pages/storagePage/StoragePage.jsx
@@ -32,6 +32,7 @@ export default function StoragePage() {
         myFolderProfile,
         editFolder,
     } = useMyFolder(targetUserId) || {};
+    console.log("째 : " , sharedFolders);
 
     // 모든 폴더를 하나의 배열로 합치기
     const allFolders = [


### PR DESCRIPTION
변경 사항
- 보관함 페이지에서 공유폴더 썸네일 4개로 볼 수 있게 변경하였습니다.
- 메인 페이지에서 무한스크롤 기능인 폴더 둘러보기에서 카드가 4열까지 보이게 기능 추가하였고, max-width : 320px 지정했습니다.