### PR TITLE
feat : 상세폴더 권한/링크 추가/로그인 분기 전반 개선

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,13 +1,13 @@
 import { useLocation } from '@tanstack/react-router';
 import { useState, useEffect } from 'react';
 
-export default function Layout({ children }) {
+export default function Layout({ children, isLoginUI = false }) {
     const location = useLocation();
     const [isSearchOpen, setIsSearchOpen] = useState(false);
 
     //check :  FollowerPage에서 margin 뺐습니다.
     const isFollowerPage = location.pathname === '/follower';
-    const isLoginPage = location.pathname === '/login';
+    const isLoginPage = isLoginUI;
 
     // 검색 오버레이 상태 감지
     useEffect(() => {
@@ -65,9 +65,11 @@ export default function Layout({ children }) {
     return (
         <div
             style={{
-                margin: isFollowerPage || isLoginPage ? '60px 0 0 0' : '60px 120px 0 120px',
+                margin: isLoginPage ? '0' : isFollowerPage ? '60px 0 0 0' : '60px 120px 0 120px',
+                // margin: isFollowerPage || isLoginPage ? '60px 0 0 0' : '60px 120px 0 120px',
                 overflow: isLoginPage ? 'hidden' : 'visible',
-                height: isFollowerPage ? 'calc(100vh - 110px)' : 'calc(100vh - 60px)',
+                // height: isFollowerPage ? 'calc(100vh - 110px)' : 'calc(100vh - 60px)',
+                height: isLoginPage ? '100vh' : isFollowerPage ? 'calc(100vh - 110px)' : 'calc(100vh - 60px)',
                 opacity: isSearchOpen ? 0 : 1,
                 transition: isSearchOpen ? 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)' : 'none',
                 pointerEvents: isSearchOpen ? 'none' : 'auto',

--- a/src/features/auth/hooks/useLogout.js
+++ b/src/features/auth/hooks/useLogout.js
@@ -1,14 +1,24 @@
 import { useNavigate } from '@tanstack/react-router';
 import { useAuthStore } from '@/stores/authStore';
+import { useModal } from '@/contexts/ModalContext';
 
 const useLogout = () => {
     const { logout } = useAuthStore();
     const navigate = useNavigate();
+    const { showConfirm } = useModal();
 
     return () => {
-        logout(); // AuthStore의 logout 함수 사용
-        alert('로그아웃 되었습니다.');
-        navigate({ to: '/' });
+        showConfirm({
+            title: '로그아웃',
+            message: '로그아웃 하시겠습니까?',
+            confirmText: '로그아웃',
+            cancelText: '취소',
+            confirmType: 'delete',
+            onConfirm: () => {
+                logout();
+                navigate({ to: '/' });
+            },
+        });
     };
 };
 

--- a/src/features/auth/hooks/userKakaoLogin.js
+++ b/src/features/auth/hooks/userKakaoLogin.js
@@ -1,8 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { useNavigate, useLocation } from '@tanstack/react-router';
 import axios from 'axios';
 import { useAuthStore } from '@/stores/authStore';
-import { loginRoute } from '@/routes/Router';
 import api from '@/utils/axiosConfig';
 
 const REST_API_KEY = import.meta.env.VITE_REST_API_KEY;
@@ -12,7 +11,8 @@ const KAKAO_TOKEN_URL = import.meta.env.VITE_KAKAO_TOKEN_URL;
 const url = import.meta.env.VITE_URL;
 
 const useKakaoLogin = () => {
-    const search = useSearch({ from: loginRoute.id });
+    // 현재 활성 경로가 어디든 동일하게 동작하도록 location에서 search 사용
+    const { search } = useLocation();
     const navigate = useNavigate();
     const { setUser, setTokens } = useAuthStore();
     const login = useRef(new Set());

--- a/src/features/create/api/createApi.js
+++ b/src/features/create/api/createApi.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import api from '@/utils/axiosConfig';
 
 const url = import.meta.env.VITE_URL;

--- a/src/features/create/components/CreateDropdown.jsx
+++ b/src/features/create/components/CreateDropdown.jsx
@@ -2,20 +2,26 @@ import React, { useState } from 'react';
 import FolderCreateModal from './FolderCreateModal';
 import LinkAddModal from './LinkAddModal';
 import '@/features/create/styles/CreateDropdown.css';
+import useCreate from '@/features/create/hooks/useCreate';
+import { useAuthStore } from '@/stores/authStore';
 
-export default function CreateDropdown({
-    openFolderModal,
-    openLinkModal,
-    showFolderModal,
-    showLinkModal,
-    closeFolderModal,
-    closeLinkModal,
-    addFolder,
-    addLink,
-    folders,
-    showFolderCreate = true, // 폴더 생성 메뉴 표시 여부
-}) {
+export default function CreateDropdown({ showFolderCreate = true, onSuccess }) {
     const [showMenu, setShowMenu] = useState(false);
+    const { user } = useAuthStore();
+    const userId = user?.userId;
+
+    // 내부 훅에서 폴더 로딩/모달 상태/생성까지 모두 관리
+    const {
+        addFolder,
+        addLink,
+        showFolderModal,
+        showLinkModal,
+        openFolderModal,
+        openLinkModal,
+        closeFolderModal,
+        closeLinkModal,
+        folders,
+    } = useCreate(undefined, userId, onSuccess);
 
     return (
         <>
@@ -24,7 +30,7 @@ export default function CreateDropdown({
             </button>
             {showMenu && (
                 <div className="CreateDropdownMenu" onMouseLeave={() => setShowMenu(false)}>
-                    {showFolderCreate && ( // 조건부로 폴더 생성 메뉴 표시
+                    {showFolderCreate && (
                         <button
                             onClick={() => {
                                 openFolderModal();

--- a/src/features/create/components/LinkAddModal.jsx
+++ b/src/features/create/components/LinkAddModal.jsx
@@ -16,7 +16,7 @@ export default function LinkAddModal({ onClose, onSubmit, folders = [] }) {
 
     console.log('folderId', folderId);
     console.log('currentFolder', currentFolder);
-    console.log('folders', folders);
+    console.log('folders@@@@@@@@@@@@@@@@@@@@@@@@@@@@@', folders);
     console.log('folders[0].folderId:', folders[0]?.folderId, typeof folders[0]?.folderId);
 
     const handlePaste = async () => {

--- a/src/features/create/hooks/useCreate.js
+++ b/src/features/create/hooks/useCreate.js
@@ -1,10 +1,35 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { createMyFolder, createLink } from '../api/createApi';
+import { getMyFolders } from '@/features/storage/api/myFolderApi';
 
-export default function useCreate(folders = [], userId, onSuccess) {
+export default function useCreate(initialFolders = [], userId, onSuccess) {
     // 모달 상태 관리
     const [showFolderModal, setShowFolderModal] = useState(false);
     const [showLinkModal, setShowLinkModal] = useState(false);
+    const [fetchedFolders, setFetchedFolders] = useState([]);
+    const [loadingFolders, setLoadingFolders] = useState(false);
+
+    // 초기 폴더가 비어 있고 userId가 있으면 1회만 폴더 목록 로드
+    const ensureFoldersLoaded = useCallback(async () => {
+        if (!userId) return;
+        if ((initialFolders && initialFolders.length > 0) || fetchedFolders.length > 0) return;
+        if (loadingFolders) return;
+        setLoadingFolders(true);
+        try {
+            const data = await getMyFolders(userId);
+            const own = (data?.ownFolders || []).map((f) => ({ ...f, type: 'own' }));
+            const shared = (data?.sharedFolders || []).map((f) => ({ ...f, type: 'shared' }));
+            setFetchedFolders([...own, ...shared]);
+        } catch (e) {
+            console.error('폴더 목록 로딩 실패:', e);
+        } finally {
+            setLoadingFolders(false);
+        }
+    }, [userId, initialFolders, fetchedFolders.length, loadingFolders]);
+
+    const folders = useMemo(() => {
+        return initialFolders && initialFolders.length > 0 ? initialFolders : fetchedFolders;
+    }, [initialFolders, fetchedFolders]);
 
     // 폴더 추가 함수
     const addFolder = async (data) => {
@@ -36,7 +61,10 @@ export default function useCreate(folders = [], userId, onSuccess) {
 
     // 모달 열기 함수들
     const openFolderModal = () => setShowFolderModal(true);
-    const openLinkModal = () => setShowLinkModal(true);
+    const openLinkModal = async () => {
+        await ensureFoldersLoaded();
+        setShowLinkModal(true);
+    };
 
     // 모달 닫기 함수들
     const closeFolderModal = () => setShowFolderModal(false);

--- a/src/features/create/hooks/useCreate.js
+++ b/src/features/create/hooks/useCreate.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { createMyFolder, createLink } from '../api/createApi';
 import { getMyFolders } from '@/features/storage/api/myFolderApi';
 

--- a/src/features/folderDetail/components/LinkList.jsx
+++ b/src/features/folderDetail/components/LinkList.jsx
@@ -28,7 +28,9 @@ const LinkList = ({
                     />
                     {folderInfo?.visible ? '공개' : '비공개'}
                 </div>
-                <SharedUsersPanel users={invitedUsers} loading={sharingLoading} onManage={onOpenPermission} />
+                {folderInfo?.share && (
+                    <SharedUsersPanel users={invitedUsers} loading={sharingLoading} onManage={onOpenPermission} />
+                )}
             </div>
             {links.length === 0 ? (
                 <div className="LinkListEmpty">

--- a/src/features/folderDetail/hooks/useFolderDetail.js
+++ b/src/features/folderDetail/hooks/useFolderDetail.js
@@ -22,7 +22,6 @@ export default function useFolderDetail(folderId, targetUserId) {
 
             const data = await getFolderDetail(folderId, targetUserId);
 
-
             // 폴더 정보 분리
             const { links: linksList, ...folderData } = data;
 

--- a/src/features/folderDetail/hooks/useFolderDetail.js
+++ b/src/features/folderDetail/hooks/useFolderDetail.js
@@ -1,17 +1,14 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { getFolderDetail } from '../api/folderDetailApi';
-import { useAuthStore } from '@/stores/authStore';
 
 export default function useFolderDetail(folderId, targetUserId) {
     const [folderInfo, setFolderInfo] = useState(null);
     const [links, setLinks] = useState([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
-    const { user } = useAuthStore();
-    const userId = user?.userId;
 
     // 폴더 상세 정보 및 링크 목록 조회
-    const fetchFolderDetail = async () => {
+    const fetchFolderDetail = useCallback(async () => {
         if (!folderId || !targetUserId) return;
 
         setLoading(true);
@@ -33,11 +30,11 @@ export default function useFolderDetail(folderId, targetUserId) {
         } finally {
             setLoading(false);
         }
-    };
+    }, [folderId, targetUserId]);
 
     useEffect(() => {
         fetchFolderDetail();
-    }, [folderId, targetUserId]);
+    }, [fetchFolderDetail]);
 
     return {
         folderInfo,

--- a/src/features/storage/components/FolderHeader.jsx
+++ b/src/features/storage/components/FolderHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import '@/features/storage/styles/FolderHeader.css';
 import { useFollow } from '@/features/follow/hooks/useFollow';
 import { useAuthStore } from '@/stores/authStore';
+import { useModal } from '@/contexts/ModalContext';
 
 const url = import.meta.env.VITE_URL;
 
@@ -10,11 +11,32 @@ export default function FolderHeader({ data }) {
     const { user } = useAuthStore();
     const myUserId = user?.userId;
     const { following, isLoading, toggleFollow, performUnfollow } = useFollow(targetUserId, data?.isFollowing);
+    // 초기 팔로우 상태가 확정되기 전까지 로딩 처리
+    const isReady = Boolean(targetUserId) && (typeof following === 'boolean' || typeof data?.isFollowing === 'boolean');
+    const displayedFollowing = typeof following === 'boolean' ? following : Boolean(data?.isFollowing);
+    const { showConfirm } = useModal();
 
     const handleFollowClick = () => {
-        if (!targetUserId || isLoading) return <div>타겟유저 아이디가 없음</div>;
-        if (following) performUnfollow();
-        else toggleFollow();
+        if (!targetUserId || isLoading || !isReady) return;
+        if (following) {
+            showConfirm({
+                title: '언팔로우',
+                message: '해당 사용자를 언팔로우 하시겠습니까?',
+                confirmText: '언팔로우',
+                cancelText: '취소',
+                confirmType: 'delete',
+                onConfirm: performUnfollow,
+            });
+        } else {
+            showConfirm({
+                title: '팔로우',
+                message: '해당 사용자를 팔로우 하시겠습니까?',
+                confirmText: '팔로우',
+                cancelText: '취소',
+                confirmType: 'save',
+                onConfirm: toggleFollow,
+            });
+        }
     };
 
     return (
@@ -49,8 +71,8 @@ export default function FolderHeader({ data }) {
                 </div>
                 <div className="FollowBtnContainer">
                     {targetUserId && targetUserId !== myUserId && (
-                        <button className="FollowBtn" onClick={handleFollowClick} disabled={isLoading}>
-                            {following ? '팔로우취소' : '팔로우'}
+                        <button className="FollowBtn" onClick={handleFollowClick} disabled={isLoading || !isReady}>
+                            {!isReady || isLoading ? '로딩중...' : displayedFollowing ? '팔로우취소' : '팔로우'}
                         </button>
                     )}
                 </div>

--- a/src/features/storage/components/PermissionModal.jsx
+++ b/src/features/storage/components/PermissionModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import '@/features/storage/styles/PermissionModal.css';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -18,10 +18,18 @@ const PermissionModal = ({
 }) => {
     const { user } = useAuthStore();
     const [searchTerm, setSearchTerm] = useState('');
-    const [activeTab, setActiveTab] = useState('invite'); // 'invite' | 'permissions'
-
     // 현재 사용자가 폴더 주인인지 확인
     const isOwner = user?.userId === owner?.userId;
+    // 소유자가 아닐 경우 기본 탭을 'permissions'로 열기
+    const [activeTab, setActiveTab] = useState(isOwner ? 'invite' : 'permissions'); // 'invite' | 'permissions'
+
+    // 모달이 열릴 때마다, 그리고 소유자 여부가 바뀔 때 탭/검색어 초기화
+    useEffect(() => {
+        if (isOpen) {
+            setActiveTab(isOwner ? 'invite' : 'permissions');
+            setSearchTerm('');
+        }
+    }, [isOpen, isOwner]);
 
     // allCandidates에서 전체 검색 후 탭별로 필터링
     const filteredUsers = useMemo(() => {
@@ -96,9 +104,7 @@ const PermissionModal = ({
 
                 {/* 폴더 주인이 아닌 경우 권한 부여 불가 메시지 */}
                 {!isOwner && (
-                    <div className="PermissionDeniedMessage">
-                        폴더 소유자만 초대 및 권한을 부여할 수 있습니다.
-                    </div>
+                    <div className="PermissionDeniedMessage">폴더 소유자만 초대 및 권한을 부여할 수 있습니다.</div>
                 )}
 
                 {/* 검색창 */}
@@ -139,7 +145,9 @@ const PermissionModal = ({
                             {searchTerm
                                 ? '검색 결과가 없습니다.'
                                 : activeTab === 'invite'
-                                  ? '초대 가능한 사용자가 없습니다.'
+                                  ? isOwner
+                                      ? '초대 가능한 사용자가 없습니다.'
+                                      : '폴더 소유자만 초대가 가능합니다.'
                                   : '초대된 사용자가 없습니다.'}
                         </div>
                     )}
@@ -163,24 +171,22 @@ const PermissionModal = ({
                                     </div>
                                     <div className="UserEmail">{user.email}</div>
                                 </div>
-                                {!user.invited ? (
-                                    // 미초대 사용자: 체크박스 표시 (폴더 주인만)
-                                    isOwner && (
-                                        <input
-                                            type="checkbox"
-                                            className="UserCheckbox"
-                                            checked={isUserSelected(user)}
-                                            onChange={() => handleUserToggle(user)}
-                                        />
-                                    )
-                                ) : (
-                                    // 초대된 사용자: 삭제 버튼 표시 (폴더 주인만)
-                                    isOwner && (
-                                        <button className="RevokeButton" onClick={() => onRevoke(user.followingId)}>
-                                            삭제
-                                        </button>
-                                    )
-                                )}
+                                {!user.invited
+                                    ? // 미초대 사용자: 체크박스 표시 (폴더 주인만)
+                                      isOwner && (
+                                          <input
+                                              type="checkbox"
+                                              className="UserCheckbox"
+                                              checked={isUserSelected(user)}
+                                              onChange={() => handleUserToggle(user)}
+                                          />
+                                      )
+                                    : // 초대된 사용자: 삭제 버튼 표시 (폴더 주인만)
+                                      isOwner && (
+                                          <button className="RevokeButton" onClick={() => onRevoke(user.followingId)}>
+                                              삭제
+                                          </button>
+                                      )}
                             </div>
                         ))}
                 </div>

--- a/src/pages/storageFolderDetail/StorageFolderDetail.jsx
+++ b/src/pages/storageFolderDetail/StorageFolderDetail.jsx
@@ -120,18 +120,7 @@ export default function StorageFolderDetail() {
             />
 
             {/* Create 버튼 (링크 추가만) */}
-            <CreateDropdown
-                openFolderModal={() => {}} // 폴더 생성은 비활성화
-                openLinkModal={openLinkModal}
-                showFolderModal={false}
-                showLinkModal={showLinkModal}
-                closeFolderModal={() => {}}
-                closeLinkModal={closeLinkModal}
-                addFolder={() => {}}
-                addLink={addLink}
-                folders={folders}
-                showFolderCreate={false}
-            />
+            <CreateDropdown showFolderCreate={false} onSuccess={refetch} />
             {showPermissionModal && (
                 <PermissionModal
                     isOpen={showPermissionModal}

--- a/src/pages/storageFolderDetail/StorageFolderDetail.jsx
+++ b/src/pages/storageFolderDetail/StorageFolderDetail.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { getRouteApi } from '@tanstack/react-router';
 import { useAuthStore } from '@/stores/authStore';
 import useFolderDetail from '@/features/folderDetail/hooks/useFolderDetail';
-import useCreate from '@/features/create/hooks/useCreate';
 import FolderDetailHeader from '@/features/folderDetail/components/FolderDetailHeader';
 import LinkList from '@/features/folderDetail/components/LinkList';
 import CreateDropdown from '@/features/create/components/CreateDropdown';
@@ -29,12 +28,7 @@ export default function StorageFolderDetail() {
     // 폴더 상세 정보 및 링크 목록 조회
     const { folderInfo, links, loading, error, refetch } = useFolderDetail(folderId, targetUserId);
 
-    // useCreate 훅 사용 (URL 파라미터로 받은 전체 폴더 + 현재 폴더 ID, 디폴트 폴더 ID)
-    const { addLink, showLinkModal, openLinkModal, closeLinkModal, folders } = useCreate(
-        userId,
-        refetch,
-        folderId // 현재 폴더 ID를 기본값으로 설정
-    );
+    // 링크 추가는 CreateDropdown 내부에서 독립적으로 처리
 
     // 권한 데이터: 페이지 진입 시 1회 로드 → 아이콘/모달에서 공통 사용
     const [permData, setPermData] = React.useState(null);
@@ -60,7 +54,7 @@ export default function StorageFolderDetail() {
         return () => {
             ignore = true;
         };
-    }, [folderId, folderInfo?.share]);
+    }, [folderId, folderInfo]);
 
     // 아이콘 표시에 사용할 원본 invited 목록만 전달 (가공은 컴포넌트가 담당)
     const invitedUsers = Array.isArray(permData?.invited) ? permData.invited : [];
@@ -72,7 +66,7 @@ export default function StorageFolderDetail() {
         getFolderPermissionList(folderId)
             .then((data) => setPermData(data))
             .finally(() => setPermLoading(false));
-    }, [folderId, folderInfo?.share]);
+    }, [folderId, folderInfo]);
 
     const {
         users: permUsers,

--- a/src/pages/storageFolderDetail/StorageFolderDetail.jsx
+++ b/src/pages/storageFolderDetail/StorageFolderDetail.jsx
@@ -8,6 +8,7 @@ import LinkList from '@/features/folderDetail/components/LinkList';
 import CreateDropdown from '@/features/create/components/CreateDropdown';
 import { getFolderPermissionList } from '@/features/storage/api/folderPermissionApi';
 import PermissionModal from '@/features/storage/components/PermissionModal';
+import usePermissionUsers from '@/features/storage/hooks/usePermissionUsers';
 
 const routeApi = getRouteApi('/folder/$folderId');
 
@@ -17,12 +18,9 @@ export default function StorageFolderDetail() {
 
     // URL 파라미터에서 정보 추출
     const searchParams = new URLSearchParams(window.location.search);
-    const defaultFolderId = searchParams.get('defaultFolderId');
-    const allFoldersParam = searchParams.get('allFolders');
     const targetUserId = searchParams.get('targetUserId');
 
     // 전체 폴더 정보 파싱
-    const parsedAllFolders = allFoldersParam ? JSON.parse(decodeURIComponent(allFoldersParam)) : [];
 
     // 사용자 정보 가져오기
     const { user } = useAuthStore();
@@ -33,20 +31,23 @@ export default function StorageFolderDetail() {
 
     // useCreate 훅 사용 (URL 파라미터로 받은 전체 폴더 + 현재 폴더 ID, 디폴트 폴더 ID)
     const { addLink, showLinkModal, openLinkModal, closeLinkModal, folders } = useCreate(
-        parsedAllFolders, // URL 파라미터로 받은 전체 폴더 정보
         userId,
         refetch,
-        defaultFolderId,
         folderId // 현재 폴더 ID를 기본값으로 설정
     );
 
     // 권한 데이터: 페이지 진입 시 1회 로드 → 아이콘/모달에서 공통 사용
     const [permData, setPermData] = React.useState(null);
     const [permLoading, setPermLoading] = React.useState(false);
-    const [showPerm, setShowPerm] = React.useState(false);
+    // 모달 동작은 훅에서 관리
 
     React.useEffect(() => {
-        if (!folderId) return;
+        if (!folderId || !folderInfo || folderInfo.share === false) {
+            // 공유되지 않은 폴더면 요청 스킵 및 상태 초기화
+            setPermData(null);
+            setPermLoading(false);
+            return;
+        }
         let ignore = false;
         setPermLoading(true);
         getFolderPermissionList(folderId)
@@ -59,10 +60,35 @@ export default function StorageFolderDetail() {
         return () => {
             ignore = true;
         };
-    }, [folderId]);
+    }, [folderId, folderInfo?.share]);
 
     // 아이콘 표시에 사용할 원본 invited 목록만 전달 (가공은 컴포넌트가 담당)
     const invitedUsers = Array.isArray(permData?.invited) ? permData.invited : [];
+
+    // 훅: 모달 동작(선택/부여/삭제) 담당. 성공 후 페이지 권한 데이터 새로고침
+    const refreshPermData = React.useCallback(() => {
+        if (!folderId || !folderInfo || folderInfo.share === false) return;
+        setPermLoading(true);
+        getFolderPermissionList(folderId)
+            .then((data) => setPermData(data))
+            .finally(() => setPermLoading(false));
+    }, [folderId, folderInfo?.share]);
+
+    const {
+        users: permUsers,
+        invitedUsers: hookInvited,
+        notInvitedUsers: hookNotInvited,
+        owner: permOwner,
+        loading: hookLoading,
+        error: hookError,
+        showPermissionModal,
+        selectedUsers,
+        openPermissionModal,
+        closePermissionModal,
+        handleUserSelect,
+        handlePermissionConfirm,
+        handlePermissionRevoke,
+    } = usePermissionUsers(userId, refreshPermData);
 
     if (loading) {
         return (
@@ -90,7 +116,7 @@ export default function StorageFolderDetail() {
                 refetch={refetch}
                 invitedUsers={invitedUsers}
                 sharingLoading={permLoading}
-                onOpenPermission={() => setShowPerm(true)}
+                onOpenPermission={() => openPermissionModal({ folderId, folderName: folderInfo?.folderName })}
             />
 
             {/* Create 버튼 (링크 추가만) */}
@@ -106,20 +132,20 @@ export default function StorageFolderDetail() {
                 folders={folders}
                 showFolderCreate={false}
             />
-            {showPerm && (
+            {showPermissionModal && (
                 <PermissionModal
-                    isOpen={showPerm}
-                    users={permData?.allCandidates || []}
-                    invitedUsers={permData?.invited || []}
-                    notInvitedUsers={permData?.notInvited || []}
-                    owner={permData?.owner || null}
-                    selectedUsers={[]}
-                    onUserSelect={() => {}}
-                    onClose={() => setShowPerm(false)}
-                    onConfirm={() => {}}
-                    onRevoke={() => {}}
-                    loading={permLoading}
-                    error={null}
+                    isOpen={showPermissionModal}
+                    users={permUsers}
+                    invitedUsers={hookInvited}
+                    notInvitedUsers={hookNotInvited}
+                    owner={permOwner}
+                    selectedUsers={selectedUsers}
+                    onUserSelect={handleUserSelect}
+                    onClose={closePermissionModal}
+                    onConfirm={handlePermissionConfirm}
+                    onRevoke={handlePermissionRevoke}
+                    loading={hookLoading}
+                    error={hookError}
                 />
             )}
         </div>

--- a/src/pages/storagePage/StoragePage.jsx
+++ b/src/pages/storagePage/StoragePage.jsx
@@ -4,7 +4,6 @@ import { getRouteApi } from '@tanstack/react-router';
 import { useAuthStore } from '@/stores/authStore';
 import { useModal } from '@/contexts/ModalContext';
 import useMyFolder from '@/features/storage/hooks/useMyFolder';
-import useCreate from '@/features/create/hooks/useCreate';
 import FolderHeader from '@/features/storage/components/FolderHeader';
 import FolderList from '@/features/storage/components/MyFolderList';
 import CreateDropdown from '@/features/create/components/CreateDropdown';

--- a/src/pages/storagePage/StoragePage.jsx
+++ b/src/pages/storagePage/StoragePage.jsx
@@ -19,7 +19,7 @@ export default function StoragePage() {
     const { user } = useAuthStore();
     const { showConfirm } = useModal();
     const currentUserId = user?.userId;
-    
+
     // URL의 userId와 현재 로그인한 사용자의 userId가 다르면 다른 사람의 보관함
     const isOwnStorage = routeUserId === currentUserId?.toString();
     const targetUserId = routeUserId || currentUserId;
@@ -39,18 +39,7 @@ export default function StoragePage() {
         ...sharedFolders.map((folder) => ({ ...folder, type: 'shared' })),
     ];
 
-    // useCreate 훅 사용 (모든 로직 포함)
-    const {
-        addFolder,
-        addLink,
-        showFolderModal,
-        showLinkModal,
-        openFolderModal,
-        openLinkModal,
-        closeFolderModal,
-        closeLinkModal,
-        folders,
-    } = useCreate(allFolders, targetUserId, fetchFolders);
+    // 링크 추가는 드롭다운 내부에서 독립적으로 처리 (페이지 제어 제거)
 
     const {
         users: followingUsers,
@@ -109,23 +98,8 @@ export default function StoragePage() {
         <div className="StorageContainer" style={{ paddingBottom: '120px' }}>
             <FolderHeader data={myFolderProfile} />
             <div className="StorageHeader">
-                <h2 className="StorageTitle">
-                    {isOwnStorage ? `${user.nickname}님의 폴더` : `사용자의 폴더`}
-                </h2>
-                {isOwnStorage && (
-                    <CreateDropdown
-                        openFolderModal={openFolderModal}
-                        openLinkModal={openLinkModal}
-                        showFolderModal={showFolderModal}
-                        showLinkModal={showLinkModal}
-                        closeFolderModal={closeFolderModal}
-                        closeLinkModal={closeLinkModal}
-                        addFolder={addFolder}
-                        addLink={addLink}
-                        folders={folders}
-                        showFolderCreate={true}
-                    />
-                )}
+                <h2 className="StorageTitle">{isOwnStorage ? `${user.nickname}님의 폴더` : `사용자의 폴더`}</h2>
+                {isOwnStorage && <CreateDropdown showFolderCreate onSuccess={fetchFolders} />}
             </div>
             <FolderList
                 folders={ownFolders}

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,31 +1,40 @@
 import { createRootRoute, createRoute, createRouter, RouterProvider } from '@tanstack/react-router';
-import { Outlet } from '@tanstack/react-router';
+import { Outlet, useLocation } from '@tanstack/react-router';
 import Header from '@/features/header/components/Header';
 import Layout from '@/components/layout/Layout';
+import { useAuthStore } from '@/stores/authStore';
 
 import MainPage from '@/pages/mainPage/MainPage';
 import LoginPage from '@/pages/loginPage/LoginPage';
-
 import FollowerPage from '@/pages/FollowerPage/FollowerPage';
 import EditProfilePage from '@/pages/userPage/EditProfilePage';
-import { ModalProvider } from '@/contexts/ModalContext';
-import ModalRenderer from '@/components/common/ModalRenderer';
 import StoragePage from '@/pages/storagePage/StoragePage';
 import StorageFolderDetail from '@/pages/storageFolderDetail/StorageFolderDetail';
 import SearchPage from '@/pages/SearchPage/SearchPage';
 
-const rootRoute = createRootRoute({
-    component: () => (
+import { ModalProvider } from '@/contexts/ModalContext';
+import ModalRenderer from '@/components/common/ModalRenderer';
+
+function RootPage() {
+    const { user } = useAuthStore();
+    const userId = user?.userId;
+    const location = useLocation();
+    const isRootAndGuest = location.pathname === '/' && !userId;
+    const isLoginPath = location.pathname === '/login';
+    const showHeader = !(isLoginPath || isRootAndGuest);
+    return (
         <>
             <ModalProvider>
-                <Header />
-                <Layout>
-                    <Outlet />
-                </Layout>
+                {showHeader && <Header />}
+                <Layout isLoginUI={isRootAndGuest}>{isRootAndGuest ? <LoginPage /> : <Outlet />}</Layout>
                 <ModalRenderer />
             </ModalProvider>
         </>
-    ),
+    );
+}
+
+const rootRoute = createRootRoute({
+    component: RootPage,
 });
 
 const mainRoute = createRoute({


### PR DESCRIPTION
### 완료사항
- 상세 폴더 권한 조회/제어 로직 개선 및 불필요 요청 차단
- 링크 추가 드롭다운 미표시 버그 해결(내부 폴더 로딩/캐시)
- 팔로우/언팔로우, 로그아웃 컨펌 모달 적용
- 폴더 헤더 팔로우 버튼 로딩/초기값 반영
- 루트 기반 로그인 분기 + 로그인 UI 헤더 제거/마진 0 처리
- 카카오 로그인 훅 경로 의존성 제거
- ESLint 경고 제거 및 코드 정리
