### PR TITLE
feat : 링크 이동/중복요청 방지/글자수 제한/보호 라우트 컨펌 등 전반 개선

### DIFF
--- a/src/components/common/ConfirmModal.css
+++ b/src/components/common/ConfirmModal.css
@@ -84,7 +84,7 @@
 }
 
 .ConfirmModalConfirmBtn--save {
-    background: #5a9cf8;
+    background: #5ab7fc;
     color: white;
 }
 

--- a/src/contexts/ModalContext.jsx
+++ b/src/contexts/ModalContext.jsx
@@ -55,7 +55,10 @@ export const ModalProvider = ({ children }) => {
                         confirmModal.onConfirm?.();
                         hideConfirm();
                     }}
-                    onCancel={hideConfirm}
+                    onCancel={() => {
+                        confirmModal.onCancel?.();
+                        hideConfirm();
+                    }}
                 />
             )}
         </ModalContext.Provider>

--- a/src/features/create/components/CreateDropdown.jsx
+++ b/src/features/create/components/CreateDropdown.jsx
@@ -21,6 +21,8 @@ export default function CreateDropdown({ showFolderCreate = true, onSuccess }) {
         closeFolderModal,
         closeLinkModal,
         folders,
+        creatingFolder,
+        creatingLink,
     } = useCreate(undefined, userId, onSuccess);
 
     return (
@@ -52,10 +54,19 @@ export default function CreateDropdown({ showFolderCreate = true, onSuccess }) {
             )}
 
             {/* 폴더 생성 모달 */}
-            {showFolderModal && <FolderCreateModal onClose={closeFolderModal} onSubmit={addFolder} />}
+            {showFolderModal && (
+                <FolderCreateModal onClose={closeFolderModal} onSubmit={addFolder} folderSubmitting={creatingFolder} />
+            )}
 
             {/* 링크 추가 모달 */}
-            {showLinkModal && <LinkAddModal onClose={closeLinkModal} onSubmit={addLink} folders={folders} />}
+            {showLinkModal && (
+                <LinkAddModal
+                    onClose={closeLinkModal}
+                    onSubmit={addLink}
+                    folders={folders}
+                    linkSubmitting={creatingLink}
+                />
+            )}
         </>
     );
 }

--- a/src/features/create/components/FolderCreateModal.jsx
+++ b/src/features/create/components/FolderCreateModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import '@/features/create/styles/FolderCreateModal.css';
 
-export default function FolderCreateModal({ mode, initialData, onClose, onSubmit }) {
+export default function FolderCreateModal({ mode, initialData, onClose, onSubmit, folderSubmitting = false }) {
     const [folderName, setFolderName] = useState(initialData?.folderName || '');
     const [folderDescription, setFolderDescription] = useState(initialData?.folderDescription || '');
     const [visible, setVisible] = useState(initialData?.visible ?? true);
@@ -11,6 +11,7 @@ export default function FolderCreateModal({ mode, initialData, onClose, onSubmit
             alert('폴더 제목을 입력해주세요.');
             return;
         }
+        if (folderSubmitting) return;
         onSubmit({ folderName, folderDescription, visible });
     };
 
@@ -65,8 +66,12 @@ export default function FolderCreateModal({ mode, initialData, onClose, onSubmit
                     <button className="FolderCreateModalCancelBtn" onClick={handleFolderCancel}>
                         취소
                     </button>
-                    <button className="FolderCreateModalConfirmBtn" onClick={handleFolderSubmit}>
-                        {mode === 'edit' ? '수정' : '확인'}
+                    <button
+                        className="FolderCreateModalConfirmBtn"
+                        onClick={handleFolderSubmit}
+                        disabled={folderSubmitting}
+                    >
+                        {folderSubmitting ? '폴더 생성 중...' : mode === 'edit' ? '수정' : '확인'}
                     </button>
                 </div>
             </div>

--- a/src/features/create/components/FolderCreateModal.jsx
+++ b/src/features/create/components/FolderCreateModal.jsx
@@ -6,6 +6,9 @@ export default function FolderCreateModal({ mode, initialData, onClose, onSubmit
     const [folderDescription, setFolderDescription] = useState(initialData?.folderDescription || '');
     const [visible, setVisible] = useState(initialData?.visible ?? true);
 
+    const MAX_NAME = 20;
+    const MAX_DESC = 30;
+
     const handleFolderSubmit = () => {
         if (!folderName.trim()) {
             alert('폴더 제목을 입력해주세요.');
@@ -28,24 +31,36 @@ export default function FolderCreateModal({ mode, initialData, onClose, onSubmit
                     <label className="FolderCreateModalLabel">
                         폴더 제목 <span className="required">*</span>
                     </label>
-                    <input
-                        type="text"
-                        className="FolderCreateModalInput"
-                        placeholder="폴더 제목을 입력하세요"
-                        value={folderName}
-                        onChange={(e) => setFolderName(e.target.value)}
-                    />
+                    <div className="CreateInputWithCounter">
+                        <input
+                            type="text"
+                            className="FolderCreateModalInput"
+                            placeholder="폴더 제목을 입력하세요"
+                            value={folderName}
+                            onChange={(e) => setFolderName(e.target.value)}
+                            maxLength={MAX_NAME}
+                        />
+                        <span className="CreateInputCounter">
+                            {folderName.length} / {MAX_NAME}
+                        </span>
+                    </div>
                 </div>
 
                 <div className="FolderCreateModalField">
                     <label className="FolderCreateModalLabel">폴더 설명</label>
-                    <input
-                        type="text"
-                        className="FolderCreateModalInput"
-                        placeholder="폴더 설명을 입력하세요"
-                        value={folderDescription}
-                        onChange={(e) => setFolderDescription(e.target.value)}
-                    />
+                    <div className="CreateInputWithCounter">
+                        <input
+                            type="text"
+                            className="FolderCreateModalInput"
+                            placeholder="폴더 설명을 입력하세요"
+                            value={folderDescription}
+                            onChange={(e) => setFolderDescription(e.target.value)}
+                            maxLength={MAX_DESC}
+                        />
+                        <span className="CreateInputCounter">
+                            {folderDescription.length} / {MAX_DESC}
+                        </span>
+                    </div>
                 </div>
 
                 <div className="FolderCreateModalField">

--- a/src/features/create/components/LinkAddModal.jsx
+++ b/src/features/create/components/LinkAddModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { getRouteApi } from '@tanstack/react-router';
 import '@/features/create/styles/LinkAddModal.css';
 
-export default function LinkAddModal({ onClose, onSubmit, folders = [] }) {
+export default function LinkAddModal({ onClose, onSubmit, folders = [], linkSubmitting = false }) {
     let folderId;
     try {
         const routeApi = getRouteApi('/folder/$folderId');
@@ -33,6 +33,7 @@ export default function LinkAddModal({ onClose, onSubmit, folders = [] }) {
             alert('링크 주소를 입력해주세요.');
             return;
         }
+        if (linkSubmitting) return;
         onSubmit({ link, folderId: selectedFolder });
     };
 
@@ -95,11 +96,11 @@ export default function LinkAddModal({ onClose, onSubmit, folders = [] }) {
                 </div>
 
                 <div className="LinkAddModalButtons">
-                    <button className="LinkAddModalPaste" onClick={handlePaste}>
+                    <button className="LinkAddModalPaste" onClick={handlePaste} disabled={linkSubmitting}>
                         붙여넣기
                     </button>
-                    <button className="LinkAddModalSubmit" onClick={handleLinkSubmit}>
-                        추가하기
+                    <button className="LinkAddModalSubmit" onClick={handleLinkSubmit} disabled={linkSubmitting}>
+                        {linkSubmitting ? '링크 추가 중...' : '추가하기'}
                     </button>
                 </div>
             </div>

--- a/src/features/create/hooks/useCreate.js
+++ b/src/features/create/hooks/useCreate.js
@@ -8,6 +8,9 @@ export default function useCreate(initialFolders = [], userId, onSuccess) {
     const [showLinkModal, setShowLinkModal] = useState(false);
     const [fetchedFolders, setFetchedFolders] = useState([]);
     const [loadingFolders, setLoadingFolders] = useState(false);
+    // 생성/요청 중복 방지 플래그
+    const [creatingFolder, setCreatingFolder] = useState(false);
+    const [creatingLink, setCreatingLink] = useState(false);
 
     // 초기 폴더가 비어 있고 userId가 있으면 1회만 폴더 목록 로드
     const ensureFoldersLoaded = useCallback(async () => {
@@ -33,29 +36,37 @@ export default function useCreate(initialFolders = [], userId, onSuccess) {
 
     // 폴더 추가 함수
     const addFolder = async (data) => {
+        // 중복 클릭 방지: 생성 중에는 재요청 차단
+        if (creatingFolder) return;
+        setCreatingFolder(true);
         try {
-            console.log('data!@#!@#@!', data, userId, onSuccess);
             await createMyFolder(data, userId);
             setShowFolderModal(false);
-            if (onSuccess) onSuccess(); // 생성 성공 시 콜백 실행
+            if (onSuccess) onSuccess();
         } catch (err) {
             console.error('폴더 create 안됨 :', err);
+        } finally {
+            setCreatingFolder(false);
         }
     };
 
     // 링크 추가 함수
     const addLink = async ({ link, folderId }) => {
+        // 중복 클릭 방지
+        if (creatingLink) return;
+        setCreatingLink(true);
         try {
             const linkData = {
                 linkUrl: link,
                 foldersId: Number(folderId),
             };
-
             await createLink(linkData, userId);
             setShowLinkModal(false);
-            if (onSuccess) onSuccess(); // 생성 성공 시 콜백 실행
+            if (onSuccess) onSuccess();
         } catch (err) {
             console.error('링크 create 안됨 :', err);
+        } finally {
+            setCreatingLink(false);
         }
     };
 
@@ -87,5 +98,8 @@ export default function useCreate(initialFolders = [], userId, onSuccess) {
 
         // 데이터
         folders,
+        // 로딩 플래그(버튼 비활성화에 사용)
+        creatingFolder,
+        creatingLink,
     };
 }

--- a/src/features/create/styles/FolderCreateModal.css
+++ b/src/features/create/styles/FolderCreateModal.css
@@ -63,10 +63,22 @@
     color: #757575;
 }
 
+.CreateInputWithCounter {
+    position: relative;
+}
+
+.CreateInputCounter {
+    position: absolute;
+    right: 0;
+    bottom: -16px;
+    font-size: 11px;
+    color: #999;
+}
+
 .FolderCreateModalButtons {
     display: flex;
     gap: 8px;
-    margin-top: 8px;
+    margin-top: 24px;
 }
 
 .FolderCreateModalCancelBtn {

--- a/src/features/folderDetail/api/folderDetailApi.js
+++ b/src/features/folderDetail/api/folderDetailApi.js
@@ -23,11 +23,22 @@ export const updateLinkTitle = async (linkId, linkName) => {
 export const deleteLink = async (linkId, folderId) => {
     const res = await api.delete(`${url}/links/users/links`, {
         data: {
-            
             foldersId: folderId,
             linkId: [linkId],
         },
     });
     console.log('링크 삭제:', res.data);
+    return res.data;
+};
+
+// 링크 이동
+export const moveLink = async ({ linkId, sourceFolderId, targetFolderId }) => {
+    console.log('링크 이동:', linkId, sourceFolderId, targetFolderId);
+    const res = await api.patch(`${url}/links/users/links/move`, {
+        linkId,
+        sourceFolderId,
+        targetFolderId,
+    });
+    console.log('링크 이동:', res.data);
     return res.data;
 };

--- a/src/features/folderDetail/components/LinkList.jsx
+++ b/src/features/folderDetail/components/LinkList.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import LinkCard from './LinkCard';
 import LinkSettingsModal from './LinkSettingsModal';
+import MoveLinkModal from './MoveLinkModal';
 import useLinkSettings from '../hooks/useLinkSettings';
 import '../styles/LinkList.css';
 import SharedUsersPanel from './SharedUsersPanel';
@@ -14,8 +15,26 @@ const LinkList = ({
     sharingLoading = false,
     onOpenPermission,
 }) => {
-    const { showModal, selectedLink, openModal, closeModal, handleSave, handleDelete, handleCopyLink } =
-        useLinkSettings(userId, refetch);
+    const searchParams = new URLSearchParams(window.location.search);
+    const targetUserIdParam = searchParams.get('targetUserId');
+    const isOwner = !targetUserIdParam || Number(targetUserIdParam) === Number(userId);
+
+    const {
+        showModal,
+        selectedLink,
+        openModal,
+        closeModal,
+        handleSave,
+        handleDelete,
+        handleCopyLink,
+        // move
+        showMoveModal,
+        openMove,
+        closeMove,
+        ownFolders,
+        moving,
+        handleMove,
+    } = useLinkSettings(userId, refetch, isOwner);
 
     return (
         <div className="LinkListContainer">
@@ -52,6 +71,18 @@ const LinkList = ({
                 onSave={handleSave}
                 onDelete={handleDelete}
                 onCopyLink={handleCopyLink}
+                onMove={openMove}
+                isOwner={isOwner}
+            />
+
+            {/* 링크 이동 모달 */}
+            <MoveLinkModal
+                isOpen={showMoveModal}
+                onClose={closeMove}
+                folders={ownFolders}
+                sourceFolderId={folderInfo?.folderId}
+                onSubmit={handleMove}
+                submitting={moving}
             />
         </div>
     );

--- a/src/features/folderDetail/components/LinkSettingsModal.jsx
+++ b/src/features/folderDetail/components/LinkSettingsModal.jsx
@@ -14,16 +14,7 @@ const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink
     if (!isOpen || !link) return null;
 
     const handleSave = () => {
-        // 링크 이름이 변경되었는지 확인
-        const hasChanged = linkName !== link.linkName;
-
-        if (hasChanged) {
-            // 변경사항이 있으면 수정 확인 모달 표시
-            onSave(link, linkName); // Hook에서 확인 모달 표시 후 처리
-        } else {
-            // 변경사항이 없으면 바로 닫기
-            onClose();
-        }
+        onSave(link, linkName);
     };
 
     const handleCopyLink = () => {
@@ -37,6 +28,9 @@ const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink
     const clearInput = () => {
         setLinkName('');
     };
+
+    const titleLen = linkName ? linkName.length : 0;
+    const MAX_TITLE = 30;
 
     return (
         <>
@@ -57,12 +51,16 @@ const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink
                                 placeholder={link.linkName}
                                 className="LinkNameInput"
                                 disabled={!isOwner}
+                                maxLength={MAX_TITLE}
                             />
                             {linkName && (
                                 <button className="ClearInputBtn" onClick={clearInput}>
                                     ✕
                                 </button>
                             )}
+                            <span className="LinkNameCounter">
+                                {titleLen} / {MAX_TITLE}
+                            </span>
                         </div>
 
                         {/* 메뉴 옵션들 */}

--- a/src/features/folderDetail/components/LinkSettingsModal.jsx
+++ b/src/features/folderDetail/components/LinkSettingsModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import '../styles/LinkSettingsModal.css';
 
-const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink }) => {
+const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink, onMove, isOwner = true }) => {
     const [linkName, setLinkName] = useState('');
 
     // link가 변경될 때마다 linkName 초기화
@@ -56,6 +56,7 @@ const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink
                                 onChange={(e) => setLinkName(e.target.value)}
                                 placeholder={link.linkName}
                                 className="LinkNameInput"
+                                disabled={!isOwner}
                             />
                             {linkName && (
                                 <button className="ClearInputBtn" onClick={clearInput}>
@@ -71,10 +72,18 @@ const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink
                                 <span>링크 복사하기</span>
                             </button>
 
-                            <button className="LinkSettingsMenuItem DeleteItem" onClick={handleDelete}>
-                                <img src="/delete.png" alt="삭제" className="LinkSettingsIcon" />
-                                <span>삭제하기</span>
-                            </button>
+                            {isOwner && (
+                                <>
+                                    <button className="LinkSettingsMenuItem" onClick={() => onMove && onMove(link)}>
+                                        <img src="/edit_folder.png" alt="이동" className="LinkSettingsIcon" />
+                                        <span>링크 이동하기</span>
+                                    </button>
+                                    <button className="LinkSettingsMenuItem DeleteItem" onClick={handleDelete}>
+                                        <img src="/delete.png" alt="삭제" className="LinkSettingsIcon" />
+                                        <span>삭제하기</span>
+                                    </button>
+                                </>
+                            )}
                         </div>
                     </div>
 
@@ -82,9 +91,11 @@ const LinkSettingsModal = ({ isOpen, link, onClose, onSave, onDelete, onCopyLink
                         <button className="LinkSettingsBtn CancelBtn" onClick={onClose}>
                             취소
                         </button>
-                        <button className="LinkSettingsBtn ConfirmBtn" onClick={handleSave}>
-                            확인
-                        </button>
+                        {isOwner && (
+                            <button className="LinkSettingsBtn ConfirmBtn" onClick={handleSave}>
+                                확인
+                            </button>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/features/folderDetail/components/MoveLinkModal.jsx
+++ b/src/features/folderDetail/components/MoveLinkModal.jsx
@@ -1,0 +1,49 @@
+import React, { useMemo, useState } from 'react';
+import '../styles/LinkSettingsModal.css';
+
+export default function MoveLinkModal({ isOpen, onClose, folders = [], sourceFolderId, onSubmit, submitting }) {
+    const ownFolders = useMemo(() => (Array.isArray(folders) ? folders : []), [folders]);
+    const [target, setTarget] = useState('');
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="LinkSettingsModalOverlay" onClick={onClose}>
+            <div className="LinkSettingsModal" onClick={(e) => e.stopPropagation()}>
+                <div className="LinkSettingsModalHeader">
+                    <h2>링크 이동</h2>
+                </div>
+                <div className="LinkSettingsModalContent">
+                    <div className="LinkNameInputWrapper">
+                        <select className="LinkNameInput" value={target} onChange={(e) => setTarget(e.target.value)}>
+                            <option value="" disabled>
+                                이동할 폴더를 선택하세요
+                            </option>
+                            {ownFolders.map((f) => (
+                                <option
+                                    key={f.folderId}
+                                    value={f.folderId}
+                                    disabled={Number(f.folderId) === Number(sourceFolderId)}
+                                >
+                                    {f.folderName}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
+                <div className="LinkSettingsModalFooter">
+                    <button className="LinkSettingsBtn CancelBtn" onClick={onClose}>
+                        취소
+                    </button>
+                    <button
+                        className="LinkSettingsBtn ConfirmBtn"
+                        onClick={() => onSubmit && onSubmit(Number(target))}
+                        disabled={!target || Number(target) === Number(sourceFolderId) || submitting}
+                    >
+                        {submitting ? '이동 중...' : '이동하기'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/features/folderDetail/components/MoveLinkModal.jsx
+++ b/src/features/folderDetail/components/MoveLinkModal.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import '../styles/LinkSettingsModal.css';
+import '../styles/MoveLinkModal.css';
 
 export default function MoveLinkModal({ isOpen, onClose, folders = [], sourceFolderId, onSubmit, submitting }) {
     const ownFolders = useMemo(() => (Array.isArray(folders) ? folders : []), [folders]);
@@ -8,14 +8,18 @@ export default function MoveLinkModal({ isOpen, onClose, folders = [], sourceFol
     if (!isOpen) return null;
 
     return (
-        <div className="LinkSettingsModalOverlay" onClick={onClose}>
-            <div className="LinkSettingsModal" onClick={(e) => e.stopPropagation()}>
-                <div className="LinkSettingsModalHeader">
+        <div className="MoveLinkModalOverlay" onClick={onClose}>
+            <div className="MoveLinkModal" onClick={(e) => e.stopPropagation()}>
+                <div className="MoveLinkModalHeader">
                     <h2>링크 이동</h2>
                 </div>
-                <div className="LinkSettingsModalContent">
-                    <div className="LinkNameInputWrapper">
-                        <select className="LinkNameInput" value={target} onChange={(e) => setTarget(e.target.value)}>
+                <div className="MoveLinkModalContent">
+                    <div className="MoveLinkModalSelectWrapper">
+                        <select
+                            className="MoveLinkModalSelect"
+                            value={target}
+                            onChange={(e) => setTarget(e.target.value)}
+                        >
                             <option value="" disabled>
                                 이동할 폴더를 선택하세요
                             </option>
@@ -31,12 +35,12 @@ export default function MoveLinkModal({ isOpen, onClose, folders = [], sourceFol
                         </select>
                     </div>
                 </div>
-                <div className="LinkSettingsModalFooter">
-                    <button className="LinkSettingsBtn CancelBtn" onClick={onClose}>
+                <div className="MoveLinkModalFooter">
+                    <button className="MoveLinkModalBtn MoveLinkModalCancelBtn" onClick={onClose}>
                         취소
                     </button>
                     <button
-                        className="LinkSettingsBtn ConfirmBtn"
+                        className="MoveLinkModalBtn MoveLinkModalConfirmBtn"
                         onClick={() => onSubmit && onSubmit(Number(target))}
                         disabled={!target || Number(target) === Number(sourceFolderId) || submitting}
                     >

--- a/src/features/folderDetail/hooks/useLinkSettings.js
+++ b/src/features/folderDetail/hooks/useLinkSettings.js
@@ -1,12 +1,17 @@
 import { useState } from 'react';
 import { getRouteApi } from '@tanstack/react-router';
 import { useModal } from '@/contexts/ModalContext';
-import { updateLinkTitle, deleteLink } from '@/features/folderDetail/api/folderDetailApi';
+import { updateLinkTitle, deleteLink, moveLink } from '@/features/folderDetail/api/folderDetailApi';
+import { getMyFolders } from '@/features/storage/api/myFolderApi';
 
-export default function useLinkSettings(userId, refetch) {
+export default function useLinkSettings(userId, refetch, isOwner) {
     const { showConfirm } = useModal();
     const [selectedLink, setSelectedLink] = useState(null);
     const [showModal, setShowModal] = useState(false);
+    const [showMoveModal, setShowMoveModal] = useState(false);
+    const [ownFolders, setOwnFolders] = useState([]);
+    const [loadingFolders, setLoadingFolders] = useState(false);
+    const [moving, setMoving] = useState(false);
     const routeApi = getRouteApi('/folder/$folderId');
     const { folderId } = routeApi.useParams();
 
@@ -20,6 +25,31 @@ export default function useLinkSettings(userId, refetch) {
         setSelectedLink(null);
     };
 
+    const ensureOwnFolders = async () => {
+        if (!isOwner || !userId) return;
+        if (ownFolders.length > 0 || loadingFolders) return;
+        setLoadingFolders(true);
+        try {
+            const data = await getMyFolders(userId);
+            const own = (data?.ownFolders || []).map((f) => ({ folderId: f.folderId, folderName: f.folderName }));
+            setOwnFolders(own);
+        } catch (e) {
+            console.error('내 폴더 목록 로딩 실패:', e);
+        } finally {
+            setLoadingFolders(false);
+        }
+    };
+
+    const openMove = async () => {
+        if (!isOwner) return;
+        await ensureOwnFolders();
+        setShowMoveModal(true);
+    };
+
+    const closeMove = () => {
+        setShowMoveModal(false);
+    };
+
     const handleSave = (link, newName) => {
         showConfirm({
             title: '확인',
@@ -30,8 +60,7 @@ export default function useLinkSettings(userId, refetch) {
             onConfirm: async () => {
                 try {
                     await updateLinkTitle(link.linkId, newName);
-                    // Hook에서 상태 관리
-                    refetch(); // 링크 목록 새로고침
+                    refetch();
                     closeModal();
                 } catch (error) {
                     console.error('링크 수정 실패:', error);
@@ -52,8 +81,7 @@ export default function useLinkSettings(userId, refetch) {
                 try {
                     const currentFolderId = Number(folderId || link.folderId);
                     await deleteLink(link.linkId, currentFolderId);
-                    // Hook에서 상태 관리
-                    refetch(); // 링크 목록 새로고침
+                    refetch();
                     closeModal();
                 } catch (error) {
                     console.error('링크 삭제 실패:', error);
@@ -63,7 +91,6 @@ export default function useLinkSettings(userId, refetch) {
         });
     };
 
-    // 링크 복사 함수
     const handleCopyLink = (link) => {
         navigator.clipboard.writeText(link.linkUrl);
         showConfirm({
@@ -76,6 +103,39 @@ export default function useLinkSettings(userId, refetch) {
         closeModal();
     };
 
+    const handleMove = (targetFolderId) => {
+        if (!selectedLink) return;
+        const srcId = Number(folderId || selectedLink.folderId);
+        const dstId = Number(targetFolderId);
+        if (srcId === dstId) return;
+
+        const sourceName = ownFolders.find((f) => Number(f.folderId) === srcId)?.folderName || '현재 폴더';
+        const targetName = ownFolders.find((f) => Number(f.folderId) === dstId)?.folderName || '선택한 폴더';
+
+        showConfirm({
+            title: '확인',
+            message: `‘${sourceName}’\n폴더에서\n‘${targetName}’\n폴더로 링크를 이동하시겠습니까?`,
+            confirmText: '이동',
+            cancelText: '취소',
+            confirmType: 'save',
+            onConfirm: async () => {
+                if (moving) return;
+                setMoving(true);
+                try {
+                    await moveLink({ linkId: selectedLink.linkId, sourceFolderId: srcId, targetFolderId: dstId });
+                    setShowMoveModal(false);
+                    setShowModal(false);
+                    refetch();
+                } catch (error) {
+                    console.error('링크 이동 실패:', error);
+                    alert('링크 이동에 실패했습니다.');
+                } finally {
+                    setMoving(false);
+                }
+            },
+        });
+    };
+
     return {
         selectedLink,
         showModal,
@@ -84,5 +144,14 @@ export default function useLinkSettings(userId, refetch) {
         handleSave,
         handleDelete,
         handleCopyLink,
+        // move
+        isOwner,
+        showMoveModal,
+        openMove,
+        closeMove,
+        ownFolders,
+        loadingFolders,
+        moving,
+        handleMove,
     };
 }

--- a/src/features/folderDetail/hooks/useLinkSettings.js
+++ b/src/features/folderDetail/hooks/useLinkSettings.js
@@ -51,6 +51,21 @@ export default function useLinkSettings(userId, refetch, isOwner) {
     };
 
     const handleSave = (link, newName) => {
+        const trimmed = (newName || '').trim();
+        if (isOwner && trimmed.length === 0) {
+            showConfirm({
+                title: '알림',
+                message: '링크 제목을 입력해주세요.',
+                confirmText: '확인',
+                confirmType: 'save',
+            });
+            return;
+        }
+        // 변경사항이 없으면 닫기
+        if (trimmed === (link.linkName || '')) {
+            closeModal();
+            return;
+        }
         showConfirm({
             title: '확인',
             message: '링크 이름을 수정하시겠습니까?',
@@ -59,12 +74,17 @@ export default function useLinkSettings(userId, refetch, isOwner) {
             confirmType: 'save',
             onConfirm: async () => {
                 try {
-                    await updateLinkTitle(link.linkId, newName);
+                    await updateLinkTitle(link.linkId, trimmed);
                     refetch();
                     closeModal();
                 } catch (error) {
                     console.error('링크 수정 실패:', error);
-                    alert('링크 수정에 실패했습니다.');
+                    showConfirm({
+                        title: '오류',
+                        message: '링크 수정에 실패했습니다.',
+                        confirmText: '확인',
+                        confirmType: 'delete',
+                    });
                 }
             },
         });

--- a/src/features/folderDetail/styles/LinkSettingsModal.css
+++ b/src/features/folderDetail/styles/LinkSettingsModal.css
@@ -79,6 +79,14 @@
     background: #999;
 }
 
+.LinkNameCounter {
+    position: absolute;
+    right: 12px;
+    bottom: -18px;
+    font-size: 11px;
+    color: #999;
+}
+
 /* 메뉴 옵션들 */
 .LinkSettingsMenu {
     display: flex;

--- a/src/features/folderDetail/styles/MoveLinkModal.css
+++ b/src/features/folderDetail/styles/MoveLinkModal.css
@@ -1,0 +1,91 @@
+.MoveLinkModalOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.MoveLinkModal {
+    background: white;
+    border-radius: 16px;
+    width: 90%;
+    max-width: 400px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    overflow: hidden;
+}
+
+.MoveLinkModalHeader {
+    padding: 24px 24px 20px 24px;
+    text-align: center;
+}
+
+.MoveLinkModalHeader h2 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #212120;
+}
+
+.MoveLinkModalContent {
+    padding: 24px;
+}
+
+/* 셀렉트 박스 */
+.MoveLinkModalSelectWrapper {
+    margin-bottom: 12px;
+}
+
+.MoveLinkModalSelect {
+    width: 100%;
+    padding: 12px 16px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    font-size: 14px;
+    box-sizing: border-box;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.MoveLinkModalSelect:focus {
+    border-color: #5a9cf8;
+}
+
+/* 하단 버튼들 */
+.MoveLinkModalFooter {
+    padding: 0 24px 24px 24px;
+    display: flex;
+    gap: 16px;
+}
+
+.MoveLinkModalBtn {
+    flex: 1;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 16px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.MoveLinkModalCancelBtn {
+    background: #f8f9fa;
+    color: #666;
+}
+
+.MoveLinkModalCancelBtn:hover {
+    background: #e9ecef;
+}
+
+.MoveLinkModalConfirmBtn {
+    background: #5ab7fc;
+    color: white;
+}
+
+.MoveLinkModalConfirmBtn:hover {
+    background: #4a8ce8;
+}

--- a/src/features/header/components/LoginMenu.jsx
+++ b/src/features/header/components/LoginMenu.jsx
@@ -1,7 +1,6 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import { useNavigate } from '@tanstack/react-router';
-import KakaoLoginBtn from '../../auth/components/KakaoLoginBtn';
 import useLogout from '../../auth/hooks/useLogout';
 
 const url = import.meta.env.VITE_URL;
@@ -27,7 +26,10 @@ export default function LoginMenu() {
                     </button>
                 </>
             ) : (
-                <KakaoLoginBtn className="LoginButton" />
+                // 카카오 로그인 버튼 → 로그인 페이지로 네비게이션
+                <button className="LoginButton" onClick={() => navigate({ to: '/login' })}>
+                    카카오 로그인
+                </button>
             )}
             <button className="MoreButton">⋮</button>
         </div>

--- a/src/features/profile/components/ProfileForm.jsx
+++ b/src/features/profile/components/ProfileForm.jsx
@@ -14,6 +14,12 @@ export default function ProfileForm({
     onSubmit,
     onCancel,
 }) {
+    const maxNickname = 10;
+    const maxBio = 100;
+
+    const nicknameLen = nickname ? nickname.length : 0;
+    const bioLen = bio ? bio.length : 0;
+
     const handleNicknameChange = (e) => {
         setNickname(e.target.value);
     };
@@ -24,47 +30,59 @@ export default function ProfileForm({
 
     return (
         <div className="ProfileFormContainer">
-            <div className="FormGroup">
+            <div className="ProfileFormGroup">
                 <label>닉네임</label>
-                <div className="NicknameRow">
-                    <input
-                        type="text"
-                        value={nickname}
-                        onChange={handleNicknameChange}
-                        className={`NicknameInput ${
-                            isAvailable === true ? 'Success' : isAvailable === false ? 'Error' : ''
-                        }`}
-                    />
-                    <button type="button" className="CheckBtn" onClick={checkDuplicateHandler}>
+                <div className="ProfileNicknameRow">
+                    <div className="ProfileInputWithCounter">
+                        <input
+                            type="text"
+                            value={nickname}
+                            onChange={handleNicknameChange}
+                            className={`ProfileNicknameInput ${
+                                isAvailable === true ? 'Success' : isAvailable === false ? 'Error' : ''
+                            }`}
+                            maxLength={maxNickname}
+                        />
+                        <span className="ProfileInputCounter">
+                            {nicknameLen} / {maxNickname}
+                        </span>
+                    </div>
+                    <button type="button" className="ProfileCheckBtn" onClick={checkDuplicateHandler}>
                         중복 확인
                     </button>
                 </div>
-                {message && (
-                    <p className={isAvailable === false ? 'ErrorText' : 'SuccessText'}>{message}</p>
+                {message ? (
+                    <p className={isAvailable === false ? 'ProfileErrorText' : 'ProfileSuccessText'}>{message}</p>
+                ) : (
+                    <p className="ProfileHelperText">닉네임은 10자 이내로 설정해주세요</p>
                 )}
             </div>
 
-            <div className="FormGroup">
+            <div className="ProfileFormGroup">
                 <label>이메일</label>
                 <input type="text" value={email} disabled />
             </div>
 
-            <div className="FormGroup">
+            <div className="ProfileFormGroup">
                 <label>소개</label>
-                <textarea
-                    value={bio}
-                    onChange={handleBioChange}
-                    placeholder="100자 이내로 작성해주세요"
-                    maxLength={100}
-                />
-                {console.log('소개', bio)}
+                <div className="ProfileInputWithCounter">
+                    <textarea
+                        value={bio}
+                        onChange={handleBioChange}
+                        placeholder="100자 이내로 작성해주세요"
+                        maxLength={maxBio}
+                    />
+                    <span className="ProfileInputCounter">
+                        {bioLen} / {maxBio}
+                    </span>
+                </div>
             </div>
 
-            <div className="ButtonRow">
-                <button className="CancelBtn" onClick={onCancel}>
+            <div className="ProfileButtonRow">
+                <button className="ProfileCancelBtn" onClick={onCancel}>
                     취소
                 </button>
-                <button className="SaveBtn" onClick={onSubmit}>
+                <button className="ProfileSaveBtn" onClick={onSubmit}>
                     저장
                 </button>
             </div>

--- a/src/features/profile/hook/useProfileEdit.js
+++ b/src/features/profile/hook/useProfileEdit.js
@@ -1,7 +1,7 @@
-import { useState, useContext, useEffect } from 'react';
-import { nicknameCheckApi, profileFormUpdateApi} from '@/features/profile/api/profileApi';
+import { useState, useEffect } from 'react';
+import { nicknameCheckApi, profileFormUpdateApi } from '@/features/profile/api/profileApi';
 import { useAuthStore } from '@/stores/authStore';
-import { useNavigate } from '@tanstack/react-router';
+import { useModal } from '@/contexts/ModalContext';
 
 export default function useProfileEdit(initialUser) {
     const [nickname, setNickname] = useState(initialUser.nickname || '');
@@ -9,28 +9,46 @@ export default function useProfileEdit(initialUser) {
     const [isAvailable, setIsAvailable] = useState(null);
     const [message, setMessage] = useState('');
     const { setUser } = useAuthStore();
-    const navigate = useNavigate();
+    const { showConfirm } = useModal();
 
-    // initialUser가 변경될 때마다 로컬 상태 업데이트
+    const NICKNAME_MAX = 10;
+
+    // initialUser 변경 시 폼 값 동기화 + 중복확인 상태 초기화
     useEffect(() => {
         setNickname(initialUser.nickname || '');
         setBio(initialUser.bio || '');
+        setIsAvailable(null);
+        setMessage('');
     }, [initialUser.nickname, initialUser.bio]);
 
+    // 닉네임이 바뀌면 중복확인 상태 초기화
     useEffect(() => {
         setIsAvailable(null);
         setMessage('');
     }, [nickname]);
 
     const checkDuplicateHandler = async () => {
-        if (nickname === initialUser.nickname) {
-            setIsAvailable(true);
+        const trimmed = (nickname || '').trim();
+        if (trimmed.length === 0) {
+            setIsAvailable(false);
+            setMessage('닉네임을 입력해주세요.');
+            return;
+        }
+        if (trimmed.length > NICKNAME_MAX) {
+            setIsAvailable(false);
+            setMessage(`닉네임은 ${NICKNAME_MAX}자 이내로 입력해주세요.`);
+            return;
+        }
+
+        if (trimmed === (initialUser.nickname || '')) {
+            // 현재 사용 중인 닉네임: 성공/실패가 아닌 정보성 상태로 표시
+            setIsAvailable(null);
             setMessage('현재 사용 중인 닉네임입니다.');
             return;
         }
 
         try {
-            await nicknameCheckApi(initialUser.userId, nickname);
+            await nicknameCheckApi(initialUser.userId, trimmed);
             setIsAvailable(true);
             setMessage('사용 가능한 닉네임입니다.');
         } catch (error) {
@@ -46,43 +64,89 @@ export default function useProfileEdit(initialUser) {
 
     // 닉네임, 소개 변경 저장
     const onSubmit = async () => {
-        const isNicknameChanged = nickname !== initialUser.nickname;
-        const isBioChanged = bio !== initialUser.bio;
+        const trimmed = (nickname || '').trim();
+        const isNicknameChanged = trimmed !== (initialUser.nickname || '');
+        const isBioChanged = bio !== (initialUser.bio || '');
+
+        // 유효성 검사: 빈값/길이
+        if (isNicknameChanged) {
+            if (trimmed.length === 0) {
+                showConfirm({
+                    title: '알림',
+                    message: '닉네임을 입력해주세요.',
+                    confirmText: '확인',
+                    confirmType: 'save',
+                });
+                return;
+            }
+            if (trimmed.length > NICKNAME_MAX) {
+                showConfirm({
+                    title: '알림',
+                    message: `닉네임은 ${NICKNAME_MAX}자 이내로 입력해주세요.`,
+                    confirmText: '확인',
+                    confirmType: 'save',
+                });
+                return;
+            }
+        }
 
         // 닉네임이 바뀌었고 중복 상태면 저장 막기
         if (isNicknameChanged && isAvailable === false) {
-            alert('이미 사용 중인 닉네임입니다.');
+            showConfirm({
+                title: '알림',
+                message: '이미 사용 중인 닉네임입니다.',
+                confirmText: '확인',
+                confirmType: 'save',
+            });
             return;
         }
 
         // 닉네임이 바뀌었는데 중복확인 안 했으면 저장 막기
         if (isNicknameChanged && isAvailable === null) {
-            alert('닉네임 중복 확인을 해주세요.');
+            showConfirm({
+                title: '알림',
+                message: '닉네임 중복 확인을 해주세요.',
+                confirmText: '확인',
+                confirmType: 'save',
+            });
             return;
         }
 
         // 닉네임과 소개 둘 다 안 바뀌었으면 저장 막기
         if (!isNicknameChanged && !isBioChanged) {
-            alert('변경된 내용이 없습니다.');
+            showConfirm({
+                title: '알림',
+                message: '변경된 내용이 없습니다.',
+                confirmText: '확인',
+                confirmType: 'save',
+            });
             return;
         }
 
         try {
-            const res = await profileFormUpdateApi(initialUser.userId, nickname, bio);
-            alert('프로필이 저장되었습니다!');
-            
-            // store의 user 정보 업데이트 (email과 bio는 제외)
+            const res = await profileFormUpdateApi(initialUser.userId, trimmed, bio);
+            showConfirm({
+                title: '완료',
+                message: '프로필이 저장되었습니다!',
+                confirmText: '확인',
+                confirmType: 'save',
+            });
             const updatedUser = {
                 ...initialUser,
                 nickname: res.nickname,
                 bio: res.bio,
             };
-          
             setUser(updatedUser);
-            
-            // navigate({ to: '/editProfile' });
+            // 저장 완료 후 메시지/중복확인 상태 초기화
+            setIsAvailable(null);
+            setMessage('');
         } catch (error) {
-            alert('프로필 저장 중 오류가 발생했습니다.');
+            showConfirm({
+                title: '오류',
+                message: '프로필 저장 중 오류가 발생했습니다.',
+                confirmText: '확인',
+                confirmType: 'delete',
+            });
             console.error('저장 실패:', error);
         }
     };
@@ -118,6 +182,6 @@ export default function useProfileEdit(initialUser) {
         message,
         checkDuplicateHandler,
         onSubmit,
-        // changeImageHandler,
+        nicknameMax: NICKNAME_MAX,
     };
 }

--- a/src/features/profile/styles/ProfileForm.css
+++ b/src/features/profile/styles/ProfileForm.css
@@ -4,7 +4,7 @@
     padding-top: 10px;
 }
 
-.FormGroup {
+.ProfileFormGroup {
     margin-bottom: 20px;
 }
 
@@ -22,27 +22,43 @@ textarea {
     border: 1px solid #ccc;
     border-radius: 6px;
     font-size: 14px;
+    box-sizing: border-box;
+}
+
+.ProfileInputWithCounter {
+    position: relative;
+    width: 100%;
+}
+
+.ProfileInputCounter {
+    position: absolute;
+    right: 8px;
+    bottom: 6px;
+    font-size: 11px;
+    color: #999;
+    pointer-events: none;
 }
 
 textarea {
     resize: none;
     height: 100px;
+    padding-bottom: 22px; /* counter 영역 확보 */
 }
 
-.NicknameRow {
+.ProfileNicknameRow {
     display: flex;
     gap: 10px;
 }
 
-.NicknameInput.Success {
+.ProfileNicknameInput.Success {
     border-color: green;
 }
 
-.NicknameInput.Error {
+.ProfileNicknameInput.Error {
     border-color: red;
 }
 
-.CheckBtn {
+.ProfileCheckBtn {
     padding: 0 14px;
     background-color: #5ab7fc;
     color: #fff;
@@ -53,39 +69,51 @@ textarea {
     white-space: nowrap;
 }
 
-.ErrorText {
+.ProfileErrorText {
     color: red;
     font-size: 12px;
     margin-top: 4px;
 }
 
-.SuccessText {
+.ProfileSuccessText {
     color: green;
     font-size: 12px;
     margin-top: 4px;
 }
 
-.ButtonRow {
+.ProfileHelperText {
+    color: #999;
+    font-size: 12px;
+    margin-top: 4px;
+}
+
+.ProfileButtonRow {
     display: flex;
-    justify-content: center;
     gap: 12px;
     margin-top: 20px;
 }
 
-.CancelBtn {
+.ProfileButtonRow .ProfileCancelBtn,
+.ProfileButtonRow .ProfileSaveBtn {
+    flex: 1;
+}
+
+.ProfileCancelBtn {
     padding: 10px 20px;
     background-color: #ccc;
     color: white;
     border: none;
-    border-radius: 6px;
+    border-radius: 8px;
     cursor: pointer;
+    font-size: 14px;
 }
 
-.SaveBtn {
+.ProfileSaveBtn {
     padding: 10px 20px;
-    background-color: #4baef3;
+    background-color: #5ab7fc;
     color: white;
     border: none;
-    border-radius: 6px;
+    border-radius: 8px;
     cursor: pointer;
+    font-size: 14px;
 }

--- a/src/features/storage/components/MyFolderCard.jsx
+++ b/src/features/storage/components/MyFolderCard.jsx
@@ -2,11 +2,17 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import '@/features/storage/styles/MyFolderCard.css';
 
+const MyFolderCard = ({
+    folder,
+    onDelete,
+    onEdit,
+    onPermission,
+    allFolders,
+    showMenu = true,
+    showLockIcon = false,
+}) => {
+    const { folderId, folderName, folderDescription, links, scrapCount, viewCount, visible, share } = folder;
 
-const MyFolderCard = ({ folder, onDelete, onEdit, onPermission, allFolders, showMenu = true, showLockIcon = false }) => {
-
-    const { folderId, folderName, folderDescription, links, defaultFolder, scrapCount, viewCount, visible, share } = folder;
-    console.log("째2 : ", links)
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const navigate = useNavigate();
     const cardRef = useRef(null);

--- a/src/pages/storagePage/StoragePage.jsx
+++ b/src/pages/storagePage/StoragePage.jsx
@@ -31,7 +31,7 @@ export default function StoragePage() {
         myFolderProfile,
         editFolder,
     } = useMyFolder(targetUserId) || {};
-    console.log("째 : " , sharedFolders);
+    console.log('째 : ', sharedFolders);
 
     // 모든 폴더를 하나의 배열로 합치기
     const allFolders = [

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,5 +1,6 @@
 import { createRootRoute, createRoute, createRouter, RouterProvider } from '@tanstack/react-router';
-import { Outlet, useLocation } from '@tanstack/react-router';
+import { Outlet, useLocation, useNavigate } from '@tanstack/react-router';
+import React, { useEffect, useRef } from 'react';
 import Header from '@/features/header/components/Header';
 import Layout from '@/components/layout/Layout';
 import { useAuthStore } from '@/stores/authStore';
@@ -14,23 +15,58 @@ import SearchPage from '@/pages/SearchPage/SearchPage';
 
 import { ModalProvider } from '@/contexts/ModalContext';
 import ModalRenderer from '@/components/common/ModalRenderer';
+import { useModal } from '@/contexts/ModalContext';
 
 function RootPage() {
-    const { user } = useAuthStore();
-    const userId = user?.userId;
     const location = useLocation();
-    const isRootAndGuest = location.pathname === '/' && !userId;
     const isLoginPath = location.pathname === '/login';
-    const showHeader = !(isLoginPath || isRootAndGuest);
+    const showHeader = !isLoginPath;
     return (
         <>
             <ModalProvider>
                 {showHeader && <Header />}
-                <Layout isLoginUI={isRootAndGuest}>{isRootAndGuest ? <LoginPage /> : <Outlet />}</Layout>
+                <Layout isLoginUI={isLoginPath}>{isLoginPath ? <LoginPage /> : <Outlet />}</Layout>
                 <ModalRenderer />
             </ModalProvider>
         </>
     );
+}
+
+function useLoginGuardRedirect(message) {
+    const { user } = useAuthStore();
+    const navigate = useNavigate();
+    const { showConfirm } = useModal();
+    const promptedRef = useRef(false);
+
+    useEffect(() => {
+        if (!user?.userId && !promptedRef.current) {
+            promptedRef.current = true;
+            showConfirm({
+                title: '로그인 필요',
+                message,
+                confirmText: '로그인하러 가기',
+                cancelText: '취소',
+                confirmType: 'save',
+                onConfirm: () => navigate({ to: '/login', replace: true }),
+                // 취소 시 메인으로 돌려보냄
+                onCancel: () => navigate({ to: '/', replace: true }),
+            });
+        }
+    }, [user, navigate, showConfirm, message]);
+
+    return Boolean(user?.userId);
+}
+
+function ProtectedStoragePage() {
+    const isAuthed = useLoginGuardRedirect('보관함 페이지는 로그인이 필요합니다.\n로그인 페이지로 이동하시겠습니까?');
+    if (!isAuthed) return null;
+    return <StoragePage />;
+}
+
+function ProtectedFollowerPage() {
+    const isAuthed = useLoginGuardRedirect('팔로우 페이지는 로그인이 필요합니다.\n로그인 페이지로 이동하시겠습니까?');
+    if (!isAuthed) return null;
+    return <FollowerPage />;
 }
 
 const rootRoute = createRootRoute({
@@ -46,7 +82,7 @@ const mainRoute = createRoute({
 const storageRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/storage/$userId',
-    component: StoragePage,
+    component: ProtectedStoragePage,
 });
 
 export const loginRoute = createRoute({
@@ -58,7 +94,7 @@ export const loginRoute = createRoute({
 const followerRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/follower',
-    component: FollowerPage,
+    component: ProtectedFollowerPage,
 });
 
 const editProfileRoute = createRoute({


### PR DESCRIPTION
### 완료사항
1. 폴더/링크 생성 중복 방지
- useCreate: creatingFolder/creatingLink 추가, 중복 클릭 가드
- FolderCreateModal: folderSubmitting 적용, 확인 버튼 비활/로딩 라벨
- LinkAddModal: linkSubmitting 적용, 버튼 비활/로딩 라벨
- CreateDropdown: 모달에 로딩 prop 전달

2. 링크 폴더 이동(소유자 전용)
- API 연동
- LinkSettingsModal: 소유자 전용 “이동/삭제/저장”, 비소유자 읽기 전용(+복사)
- MoveLinkModal 추가: 내 폴더 1회 로딩, 현재 폴더 선택 비활성, 이동 중 중복 클릭 방지
- 컨펌 문구 개행 적용(‘A’ \n 폴더에서 \n ‘B’ \n 폴더로 …)
- 성공 시 두 모달 닫기 및 refetch

3. 글자 수 제한/카운터/컨펌
프로필 폼
- 닉네임(10)/소개(100): 인풋 내부 카운터
- 저장/검증 알림 ConfirmModal 통일
- 중복확인 메시지 저장/재로딩 시 초기화

폴더 생성/수정
- 제목 20자/설명 30자 제한 + 인풋 내부 카운터
- 공백 제목 저장 방지

링크 제목 수정
- 30자 제한 + 인풋 내부 카운터
- 빈 제목 저장 시 컨펌 모달, 저장 전 컨펌 모달

4. 비로그인 보호 라우트 컨펌/내비
- 보관함/팔로우: 비로그인 시 컨펌 -> 로그인(replace), 취소 -> 메인(replace)
- ModalContext: onCancel 콜백 실행 후 모달 닫기
- 헤더: 카카오 로그인 클릭 시 /login 이동