### PR TITLE
feat(main): Explore/MyFolders 중앙 정렬 통일 및 무한스크롤/훅 의존성 문제 해결

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,85 @@
+pipeline {
+  agent any
+  options { timestamps() }
+
+  environment {
+    REGISTRY   = "docker.io"
+    IMAGE      = "kkrapfront/kkrap-web"
+    GIT_SHA    = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+    VERSION    = "${GIT_SHA}-${env.BUILD_NUMBER}"
+    TRACK      = "dev"                         // compose의 WEB_IMAGE_TAG=dev 기준
+
+    SSH_HOST   = "ubuntu@ci.kkrap.cloud"       // 도메인 사용
+    REMOTE_DIR = "/home/ubuntu/kkrap-app"
+  }
+
+  stages {
+    stage('Checkout') { steps { checkout scm } }
+
+
+    stage('Build & Push Image (Vite→Nginx)') {
+        when { expression { env.BRANCH_NAME ==~ /release\/.*/ } }
+        steps {
+            withCredentials([usernamePassword(
+            credentialsId: 'dockerhub-frontend',
+            usernameVariable: 'USER',
+            passwordVariable: 'PASS'
+            ),
+            file(credentialsId: 'frontend-env-production', variable: 'ENV_FILE')]) {
+
+      // Secret file (.env.production) 복사
+            sh '''
+                cp "$ENV_FILE" .env.production
+                echo "[DEBUG] Copied .env.production, size:"
+                wc -c .env.production
+            '''
+
+            sh """
+                docker build -t ${REGISTRY}/${IMAGE}:${VERSION} .
+                docker tag  ${REGISTRY}/${IMAGE}:${VERSION} ${REGISTRY}/${IMAGE}:${TRACK}
+                echo $PASS | docker login -u $USER --password-stdin
+                docker push ${REGISTRY}/${IMAGE}:${VERSION}
+                docker push ${REGISTRY}/${IMAGE}:${TRACK}
+                docker logout ${REGISTRY} || true
+            """
+            }
+        }
+    }
+    // stage('Build & Push Image (Vite→Nginx)') {
+    //   when { expression { env.BRANCH_NAME ==~ /release\/.*/ } }  // release/* 만
+    //   steps {
+    //     withCredentials([usernamePassword(
+    //       credentialsId: 'dockerhub-frontend',  // ← 프론트용 Docker Hub 크리덴셜
+    //       usernameVariable: 'USER',
+    //       passwordVariable: 'PASS'
+    //     )]) {
+    //       sh """
+    //         docker build -t ${REGISTRY}/${IMAGE}:${VERSION} .
+    //         docker tag  ${REGISTRY}/${IMAGE}:${VERSION} ${REGISTRY}/${IMAGE}:${TRACK}
+    //         echo $PASS | docker login -u $USER --password-stdin
+    //         docker push ${REGISTRY}/${IMAGE}:${VERSION}
+    //         docker push ${REGISTRY}/${IMAGE}:${TRACK}
+    //         docker logout ${REGISTRY} || true
+    //       """
+    //     }
+    //   }
+    // }
+
+    stage('Deploy to EC2') {
+      when { expression { env.BRANCH_NAME ==~ /release\/.*/ } }
+      steps {
+        sshagent(credentials: ['ec2-ssh']) {
+            sh """
+                ssh -o StrictHostKeyChecking=no ${SSH_HOST} \\
+                'cd ${REMOTE_DIR} && APP=\$(grep ^IMAGE_TAG .env | cut -d= -f2); ./deploy.sh "\$APP" "${TRACK}"'
+            """
+        }
+      }
+    }
+  }
+
+  post {
+    success { echo "Frontend deployed: ${env.BRANCH_NAME} → ${VERSION} (track:${TRACK})" }
+    failure { echo "Frontend failed: ${env.BRANCH_NAME}" }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,70 +1,133 @@
-# Getting Started with Create React App
+# 🔥 Kkrap Frontend
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Kkrap의 웹 프론트엔드 레포지토리입니다. 링크를 저장·분류·공유하고 다른 사용자와 폴더를 중심으로 소통하는 경험을 제공합니다.
 
-## Available Scripts
+## 🌈 프로젝트 소개
 
-In the project directory, you can run:
+-   링크를 손쉽게 저장하고 폴더로 관리합니다.
+-   폴더를 공개/비공개로 설정하고, 공유를 통해 다른 사용자와 협업합니다.
+-   추천/탐색(Explore) 피드에서 다른 사용자의 공개 폴더를 둘러볼 수 있습니다.
+-   팔로우/보관함/검색 등 핵심 사용자 흐름을 제공합니다.
 
-### `npm start`
+## 🧩 기술 스택
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
+-   Framework: React 18, Vite
+-   Router: @tanstack/react-router
+-   State: Zustand
+-   HTTP: Axios
+-   Styling: CSS Modules + 일반 CSS 혼용
 
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
+## 🗂 프로젝트 구조(요약)
 
-### `npm test`
+```
+src/
+  app/ App.jsx
+  components/ 공통 컴포넌트, 레이아웃, 모달
+  features/
+    auth/ 로그인/로그아웃, 카카오 로그인
+    header/ 헤더 UI 및 검색 토글
+    main/ 메인 페이지(나의 폴더, Explore)
+    storage/ 보관함, 폴더 상세
+    search/ 검색 페이지 및 오버레이
+    follow/ 팔로우
+    profile/ 프로필 편집
+  pages/ 라우트 단위 페이지
+  routes/ Router.jsx (보호 라우트/가드 포함)
+  stores/ Zustand 전역 스토어
+  utils/ axios 설정 등
+```
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+## 🚦 실행 방법
 
-### `npm run build`
+사전 요구사항: Node 18+
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+1. 설치
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```
+npm install
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+2. 개발 서버
 
-### `npm run eject`
+```
+npm start
+```
 
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+-   기본 포트: Vite (기본 5173). 브라우저가 자동 열리지 않으면 `http://localhost:5173` 접속
 
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+3. 프로덕션 빌드
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
+```
+npm run build
+npm run serve   # 빌드 결과 미리보기
+```
 
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
+## 🔐 환경 변수
 
-## Learn More
+`.env` 파일에 다음 키를 설정하세요.
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+```
+VITE_URL=백엔드_API_베이스_URL
+```
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+-   예: `VITE_URL=https://api.example.com`
 
-### Code Splitting
+## 🔎 주요 화면/흐름
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
+-   메인: 나의 폴더(가로 스크롤), 공유된 폴더, Explore(공개 폴더 둘러보기)
+-   보관함: 폴더 목록/권한/공유 사용자 관리
+-   폴더 상세: 링크 목록, 링크 추가/이동/설정
+-   검색: 최근 검색, 미리보기, 결과 정렬
+-   팔로우: 팔로우/언팔로우 및 목록
+-   프로필: 프로필 정보/이미지 수정, 계정 설정(로그아웃/탈퇴)
 
-### Analyzing the Bundle Size
+## 🧭 라우팅 및 보호 정책
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
+-   Router: `@tanstack/react-router`
+-   보호 라우트: 보관함/팔로우 등은 미로그인 시 확인 모달 후 로그인 페이지로 유도합니다.
+-   로그아웃 직후에는 가드가 즉시 메인(`/`)으로 이동하도록 처리하여 중복 모달을 방지합니다.
 
-### Making a Progressive Web App
+## ♿ 접근성/반응형
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
+-   모바일 레이아웃 최적화: 하단 탭형 네비게이션, 상단 미니바
+-   공통 중앙 래퍼(ExploreInner/섹션 래퍼)로 상단/하단 섹션 좌우 라인 통일
+-   아이콘 버튼은 의미가 필요한 경우 접근성 라벨 고려(필요 시 유지)
 
-### Advanced Configuration
+-   기본 CRA 테스트 도구(@testing-library) 의존성 포함(필요 시 확장)
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
+-   코드 스타일: 2-space, 명확한 네이밍, 함수 단일 책임
+-   공통 상수/유틸 분리, 하드코딩 최소화
+-   PR 전 린트 경고 제거, 메인 브랜치 배포 가능 상태 유지
 
-### Deployment
+## 📦 커밋 컨벤션
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
+-   feat: 새로운 기능
+-   fix: 버그 수정
+-   docs: 문서 변경(README 등)
+-   style: 포맷/세미콜론 등 비즈니스 로직 무관 변경
+-   refactor: 리팩토링(기능 동일)
+-   perf: 성능 개선
+-   test: 테스트 추가/수정
+-   chore: 빌드/환경/의존성 등 잡무
+-   ci: CI/CD 설정
+-   build: 빌드 시스템 변경
+-   revert: 커밋 되돌리기
+-   temp: 임시 변경
 
-### `npm run build` fails to minify
+## 🧑‍🤝‍🧑 팀
 
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+-   PM: 정재윤
+-   Backend: 정재윤, 김강민
+-   Frontend: 이호진, 김상우
+
+## 📅 버전 이력(Frontend)
+
+| 버전  | 날짜       | 주요 내용                                      | 비고 |
+| ----- | ---------- | ---------------------------------------------- | ---- |
+| 1.0.0 | 2025-08-25 | 초기 기능 구현, 메인/보관함/검색/팔로우/프로필 | 완료 |
+| 1.0.1 | 2025-08-26 | 팔로우, 메인 페이지 반응형 적용 및 비회원 로그인 API 추가, UI 정리                  | 완료 |
+<!-- | 1.0.2 | 예정       | 베타 테스트 릴리즈                             | 예정 | -->
+
+---
+
+문서/구성은 계속 업데이트됩니다. 질문이나 제안은 이슈로 남겨주세요.

--- a/src/features/folderDetail/api/folderDetailApi.js
+++ b/src/features/folderDetail/api/folderDetailApi.js
@@ -1,4 +1,5 @@
 import api from '@/utils/axiosConfig';
+import axios from 'axios';
 
 const url = import.meta.env.VITE_URL;
 
@@ -44,7 +45,7 @@ export const moveLink = async ({ linkId, sourceFolderId, targetFolderId }) => {
 };
 
 export const noAuthGetFolderDetail = async (folderId, targetUserId) => {
-    const res = await api.get(`${url}/folders/users/noauth/${folderId}/links/${targetUserId}`);
+    const res = await axios.get(`${url}/folders/users/noauth/${folderId}/links/${targetUserId}`);
     console.log('비회원 폴더 상세 정보 및 링크 목록:', res.data);
     return res.data;
 };

--- a/src/features/main/components/ExploreSharedSection.jsx
+++ b/src/features/main/components/ExploreSharedSection.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import useRecommendedFeed from '@/features/main/hooks/useRecommendedFeed';
 import useNoAuthMainFeed from '@/features/main/hooks/useNoAuthMainFeed';
 import MyFolderCard from '@/features/storage/components/MyFolderCard';
@@ -12,9 +12,9 @@ export default function ExploreSharedSection() {
     const userId = user?.userId;
     const isLoggedIn = !!user;
 
-    // 로그인 상태에 따라 다른 훅 사용 - 조건부 호출로 변경
-    const memberFeed = isLoggedIn ? useRecommendedFeed() : null;
-    const noAuthFeed = !isLoggedIn ? useNoAuthMainFeed() : null;
+    // 훅은 항상 호출하고 내부 동작만 enabled로 제어
+    const memberFeed = useRecommendedFeed(isLoggedIn);
+    const noAuthFeed = useNoAuthMainFeed(!isLoggedIn);
 
     // 현재 사용할 피드 데이터 결정
     const currentFeed = isLoggedIn ? memberFeed : noAuthFeed;
@@ -25,6 +25,10 @@ export default function ExploreSharedSection() {
     const lastLoadAtRef = useRef(0);
     const MIN_GAP_MS = 1200;
     const [waiting, setWaiting] = useState(false);
+    const waitingRef = useRef(false);
+    useEffect(() => {
+        waitingRef.current = waiting;
+    }, [waiting]);
     const gapTimerRef = useRef(null);
 
     const reobserveSentinel = () => {
@@ -39,9 +43,9 @@ export default function ExploreSharedSection() {
     };
 
     // loadMore 이후 상태 안전장치 (회원만 해당)
-    const safeLoadMore = () => {
-        if (!isLoggedIn) return; // 비회원은 무한스크롤 없음
-        
+    const safeLoadMore = useCallback(() => {
+        if (!isLoggedIn || !loadMore) return; // 비회원은 무한스크롤 없음
+
         try {
             const maybePromise = loadMore();
             if (maybePromise && typeof maybePromise.finally === 'function') {
@@ -52,7 +56,7 @@ export default function ExploreSharedSection() {
         } catch (_) {
             setWaiting(false);
         }
-    };
+    }, [isLoggedIn, loadMore]);
 
     // 폴더 스크랩 처리 (회원만 가능)
     const handleScrapFolder = async (folderData) => {
@@ -75,12 +79,12 @@ export default function ExploreSharedSection() {
     // 무한스크롤 설정 (회원만)
     useEffect(() => {
         if (!isLoggedIn || !sentinelRef.current) return;
-        
+
         const options = { root: null, rootMargin: '0px 0px 800px 0px', threshold: 0 };
         const io = new IntersectionObserver((entries) => {
             entries.forEach((entry) => {
                 if (!entry.isIntersecting) return;
-                if (!hasMore || loading || waiting) return;
+                if (!hasMore || loading || waitingRef.current) return;
                 const now = Date.now();
                 const delta = now - lastLoadAtRef.current;
                 const remaining = MIN_GAP_MS - delta;
@@ -106,18 +110,70 @@ export default function ExploreSharedSection() {
             ioRef.current = null;
             if (gapTimerRef.current) clearTimeout(gapTimerRef.current);
         };
-    }, [userId, isLoggedIn, hasMore, loading, waiting]);
+    }, [userId, isLoggedIn, hasMore, loading, safeLoadMore]);
 
     // 비회원일 때는 간단한 폴더 목록만 표시
     if (!isLoggedIn) {
         return (
             <section className="ExploreSharedSection">
+                <div className="ExploreInner">
+                    <div className="ExploreHeaderRow">
+                        <h2 className="ExploreTitle">폴더 둘러보기</h2>
+                    </div>
+
+                    <div className="ExploreGrid">
+                        {noAuthFeed?.items.map((folder, idx) => {
+                            const displayName = folder.nickname ?? '사용자';
+                            const avatarSrc = folder.profileImage ?? '/Kkrap_logo.png';
+                            const userFolderCreateTime = folder.createTime;
+
+                            const links =
+                                folder.thumbnailUrl || folder.faviconUrl
+                                    ? [{ thumbnailUrl: folder.thumbnailUrl, faviconUrl: folder.faviconUrl }]
+                                    : [];
+                            const adaptedFolder = { ...folder, links };
+
+                            return (
+                                <div key={`${folder.folderId}-${idx}`} className="ExploreCard">
+                                    <UserFolderCardHeader
+                                        displayName={displayName}
+                                        avatarSrc={avatarSrc}
+                                        onScrap={handleScrapFolder}
+                                        folderData={folder}
+                                        disabled={true} // 비회원은 스크랩 불가
+                                        userFolderCreateTime={userFolderCreateTime}
+                                    />
+                                    <MyFolderCard folder={adaptedFolder} showMenu={false} />
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    {noAuthFeed?.loading && (
+                        <div className="ExploreLoading" role="status" aria-live="polite">
+                            <span className="ExploreSpinner" aria-hidden="true" />
+                            <span className="ExploreLoadingText">불러오는 중…</span>
+                        </div>
+                    )}
+
+                    {noAuthFeed?.error && (
+                        <div className="ExploreError">폴더를 불러오는데 실패했습니다. 다시 시도해주세요.</div>
+                    )}
+                </div>
+            </section>
+        );
+    }
+
+    // 회원용 기존 렌더링
+    return (
+        <section className="ExploreSharedSection">
+            <div className="ExploreInner">
                 <div className="ExploreHeaderRow">
                     <h2 className="ExploreTitle">폴더 둘러보기</h2>
                 </div>
 
                 <div className="ExploreGrid">
-                    {noAuthFeed?.items.map((folder, idx) => {
+                    {items.map((folder, idx) => {
                         const displayName = folder.nickname ?? '사용자';
                         const avatarSrc = folder.profileImage ?? '/Kkrap_logo.png';
                         const userFolderCreateTime = folder.createTime;
@@ -135,7 +191,7 @@ export default function ExploreSharedSection() {
                                     avatarSrc={avatarSrc}
                                     onScrap={handleScrapFolder}
                                     folderData={folder}
-                                    disabled={true} // 비회원은 스크랩 불가
+                                    disabled={scrapLoading}
                                     userFolderCreateTime={userFolderCreateTime}
                                 />
                                 <MyFolderCard folder={adaptedFolder} showMenu={false} />
@@ -144,67 +200,17 @@ export default function ExploreSharedSection() {
                     })}
                 </div>
 
-                {noAuthFeed?.loading && (
+                {hasMore && <div ref={sentinelRef} className="ExploreSentinel" style={{ height: 1 }} />}
+
+                {(loading || waiting) && (
                     <div className="ExploreLoading" role="status" aria-live="polite">
                         <span className="ExploreSpinner" aria-hidden="true" />
-                        <span className="ExploreLoadingText">불러오는 중…</span>
+                        <span className="ExploreLoadingText">{waiting ? '잠시만요…' : '불러오는 중…'}</span>
                     </div>
                 )}
 
-                {noAuthFeed?.error && (
-                    <div className="ExploreError">
-                        폴더를 불러오는데 실패했습니다. 다시 시도해주세요.
-                    </div>
-                )}
-            </section>
-        );
-    }
-
-    // 회원용 기존 렌더링
-    return (
-        <section className="ExploreSharedSection">
-            <div className="ExploreHeaderRow">
-                <h2 className="ExploreTitle">폴더 둘러보기</h2>
+                {!hasMore && items.length > 0 && <div className="ExploreEnd">더 이상 표시할 콘텐츠가 없어요</div>}
             </div>
-
-            <div className="ExploreGrid">
-                {items.map((folder, idx) => {
-                    const displayName = folder.nickname ?? '사용자';
-                    const avatarSrc = folder.profileImage ?? '/Kkrap_logo.png';
-                    const userFolderCreateTime = folder.createTime;
-
-                    const links =
-                        folder.thumbnailUrl || folder.faviconUrl
-                            ? [{ thumbnailUrl: folder.thumbnailUrl, faviconUrl: folder.faviconUrl }]
-                            : [];
-                    const adaptedFolder = { ...folder, links };
-
-                    return (
-                        <div key={`${folder.folderId}-${idx}`} className="ExploreCard">
-                            <UserFolderCardHeader
-                                displayName={displayName}
-                                avatarSrc={avatarSrc}
-                                onScrap={handleScrapFolder}
-                                folderData={folder}
-                                disabled={scrapLoading}
-                                userFolderCreateTime={userFolderCreateTime}
-                            />
-                            <MyFolderCard folder={adaptedFolder} showMenu={false} />
-                        </div>
-                    );
-                })}
-            </div>
-
-            {hasMore && <div ref={sentinelRef} className="ExploreSentinel" style={{ height: 1 }} />}
-
-            {(loading || waiting) && (
-                <div className="ExploreLoading" role="status" aria-live="polite">
-                    <span className="ExploreSpinner" aria-hidden="true" />
-                    <span className="ExploreLoadingText">{waiting ? '잠시만요…' : '불러오는 중…'}</span>
-                </div>
-            )}
-
-            {!hasMore && items.length > 0 && <div className="ExploreEnd">더 이상 표시할 콘텐츠가 없어요</div>}
         </section>
     );
 }

--- a/src/features/main/components/MyFoldersSection.jsx
+++ b/src/features/main/components/MyFoldersSection.jsx
@@ -16,7 +16,6 @@ const MyFoldersSection = () => {
         ...ownFolders.map((folder) => ({ ...folder, type: 'own' })),
         ...sharedFolders.map((folder) => ({ ...folder, type: 'shared' })),
     ];
-    
 
     const renderGridContent = (folders) => {
         if (!user) {
@@ -53,26 +52,30 @@ const MyFoldersSection = () => {
         <>
             {/* 나의 폴더 섹션 */}
             <div className="MyFoldersSection">
-                <div className="SectionHeader">
-                    <h2 className="SectionTitle">{user ? `${user.nickname}님의 폴더` : '나의 폴더'}</h2>
-                    <span className="SectionArrow" onClick={() => navigate({ to: `/storage/${userId}` })}>
-                        &gt;
-                    </span>
+                <div className="ExploreInner">
+                    <div className="SectionHeader">
+                        <h2 className="SectionTitle">{user ? `${user.nickname}님의 폴더` : '나의 폴더'}</h2>
+                        <span className="SectionArrow" onClick={() => navigate({ to: `/storage/${userId}` })}>
+                            &gt;
+                        </span>
+                    </div>
+                    <div className={`FoldersGrid${!user ? ' FoldersGridEmpty' : ''}`}>
+                        {renderGridContent(ownFolders)}
+                    </div>
                 </div>
-                <div className={`FoldersGrid${!user ? ' FoldersGridEmpty' : ''}`}>{renderGridContent(ownFolders)}</div>
             </div>
 
             {/* 공유된 폴더 섹션 - 회원일 때만 표시 */}
             {user && (
                 <div className="SharedFoldersSection">
-                    <div className="SectionHeader">
-                        <h2 className="SectionTitle">{`${user.nickname}님과 공유된 폴더`}</h2>
-                        <span className="SectionArrow" onClick={() => navigate({ to: `/storage/${userId}` })}>
-                            &gt;
-                        </span>
-                    </div>
-                    <div className="FoldersGrid">
-                        {renderGridContent(sharedFolders)}
+                    <div className="ExploreInner">
+                        <div className="SectionHeader">
+                            <h2 className="SectionTitle">{`${user.nickname}님과 공유된 폴더`}</h2>
+                            <span className="SectionArrow" onClick={() => navigate({ to: `/storage/${userId}` })}>
+                                &gt;
+                            </span>
+                        </div>
+                        <div className="FoldersGrid">{renderGridContent(sharedFolders)}</div>
                     </div>
                 </div>
             )}

--- a/src/features/main/hooks/useNoAuthMainFeed.js
+++ b/src/features/main/hooks/useNoAuthMainFeed.js
@@ -1,18 +1,19 @@
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { fetchNoAuthMainFolders } from '@/features/main/api/recommendApi';
 
-export default function useNoAuthMainFeed() {
+export default function useNoAuthMainFeed(enabled = true) {
     const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
     const hasLoadedRef = useRef(false);
 
     const loadFolders = useCallback(async () => {
+        if (!enabled) return;
         if (loading || hasLoadedRef.current) return;
 
         setLoading(true);
         setError(null);
-        
+
         try {
             const data = await fetchNoAuthMainFolders();
             const folders = Array.isArray(data) ? data : data?.folders || [];
@@ -24,14 +25,15 @@ export default function useNoAuthMainFeed() {
         } finally {
             setLoading(false);
         }
-    }, [loading]);
+    }, [enabled, loading]);
 
     // 최초 로드 시 폴더 조회 (한 번만)
     useEffect(() => {
+        if (!enabled) return;
         if (!hasLoadedRef.current) {
             loadFolders();
         }
-    }, [loadFolders]);
+    }, [enabled, loadFolders]);
 
     return {
         items,

--- a/src/features/main/hooks/useRecommendedFeed.js
+++ b/src/features/main/hooks/useRecommendedFeed.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchRecommendedScroll, initRecommendedScroll, scrapFolder } from '@/features/main/api/recommendApi';
 
-export default function useRecommendedFeed() {
+export default function useRecommendedFeed(enabled = true) {
     const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(false);
     const [hasMore, setHasMore] = useState(true);
@@ -21,6 +21,7 @@ export default function useRecommendedFeed() {
     }, [hasMore]);
 
     const loadMore = useCallback(async () => {
+        if (!enabled) return;
         if (loadingRef.current || inFlightRef.current || !hasMoreRef.current) return;
 
         setLoading(true);
@@ -62,7 +63,7 @@ export default function useRecommendedFeed() {
             setLoading(false);
             loadingRef.current = false;
         }
-    }, []);
+    }, [enabled]);
 
     // 폴더 스크랩 처리
     const handleScrapFolder = useCallback(
@@ -97,6 +98,7 @@ export default function useRecommendedFeed() {
 
     // 최초 로드 시 초기화
     useEffect(() => {
+        if (!enabled) return;
         const initializeFeed = async () => {
             setItems([]);
             setHasMore(true);
@@ -104,12 +106,11 @@ export default function useRecommendedFeed() {
             setLoading(false);
             loadingRef.current = false;
             isInitTriedRef.current = false;
-            // 초기 1회만 호출
             await loadMore();
         };
 
         initializeFeed();
-    }, [loadMore]);
+    }, [enabled, loadMore]);
 
     return {
         items,

--- a/src/features/main/styles/ExploreSharedSection.css
+++ b/src/features/main/styles/ExploreSharedSection.css
@@ -6,6 +6,12 @@
     margin-bottom: 16px;
 }
 
+/* 중앙 래퍼: 상단 섹션과 같은 라인에 맞춘 컨텐츠 폭 */
+.ExploreInner {
+    width: min(100%, calc(4 * 320px + 3 * 24px));
+    margin: 0 auto;
+}
+
 /* 그리드 */
 /* .ExploreGrid {
     display: grid;
@@ -13,15 +19,11 @@
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     margin-top: 24px;
 } */
- .ExploreGrid {
+.ExploreGrid {
     display: grid;
     gap: 40px 32px;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     margin-top: 24px;
-
-    max-width: calc(4 * 320px + 3 * 24px); /* 카드 4개 + 간격 3개 */
-    margin-left: auto;
-    margin-right: auto;
 }
 
 /* 카드 */
@@ -91,138 +93,144 @@
     padding: 12px 0;
 }
 
-.ExploreTitle{
+.ExploreTitle {
     font-size: 24px;
     font-weight: 600;
 }
 
-
 /* 반응형 */
 
 @media (max-width: 1024px) {
-
 }
 
 /* 768px 이하: 가로형 카드 */
 @media (max-width: 768px) {
-  /* 그리드 자체는 한 줄에 1개씩 넉넉히 */
-  .ExploreGrid {
-    grid-template-columns: 1fr;
-    gap: 24px;
-    justify-items: stretch;
-  }
-
-  .ExploreHeaderRow {
-    display: flex !important;
-    justify-content: space-between !important;
-    align-items: center !important;
-    margin-bottom: 4px !important;
+    /* 그리드 자체는 한 줄에 1개씩 넉넉히 */
+    .ExploreGrid {
+        grid-template-columns: 1fr;
+        gap: 24px;
+        justify-items: stretch;
     }
 
-  /* 카드 컨테이너 */
-  .ExploreCard {
-    max-width: none;        /* 행 너비 꽉 차게 */
-    gap: 4px !important;
-  }
-  
-    .ExploreTitle{
+    .ExploreHeaderRow {
+        display: flex !important;
+        justify-content: space-between !important;
+        align-items: center !important;
+        margin-bottom: 4px !important;
+    }
+
+    /* 카드 컨테이너 */
+    .ExploreCard {
+        max-width: none; /* 행 너비 꽉 차게 */
+        gap: 4px !important;
+    }
+
+    .ExploreTitle {
         font-size: 24px;
         font-weight: 600;
         margin: 4px !important;
     }
 
-  /* ── 카드 본체를 가로 배치로 전환 ── */
-  .ExploreCard .MyFolderCard {
-    display: flex !important;
-    flex-direction: row !important;
-    align-items: center;
-    width: 94% !important;
-    height: 96px !important;         /* 전체 높이(필요시 88~110px에서 조절) */
-    border-radius: 12px !important;
-    overflow: hidden !important;
-    box-shadow: 0 1px 6px rgba(0,0,0,.15);
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  /* 왼쪽 썸네일(정사각) */
-  .ExploreCard .MyFolderImageContainer {
-    flex: 0 0 96px !important;       /* 정사각 한 변 */
-    width: 96px !important;
-    height: 96px !important;
-    border-radius: 12px !important;
-    overflow: hidden;
-  }
-
-  .ExploreCard .MyFolderImage {
-    width: 90% !important;
-    height: 90% !important;
-    object-fit: cover;               /* 꽉 채우기 */
-    border-radius: 5px 5px 5px 5px  !important;  /* 아래쪽만 둥글게 */
-  }
-
-  /* 오른쪽 정보영역 */
-  .ExploreCard .MyFolderInfo {
-    flex: 1 1 auto !important;
-    height: auto !important;
-    padding: 8px 12px !important;
-    background: transparent !important;
-    border-radius: 0 !important;
-  }
-  
-  .ExploreCard .MyFolderTitle {
-    font-size: 14px !important;
-    font-weight: 700;
-    line-height: 1.2;
-    margin-bottom: 0px !important;
-    
-    line-height: 1.1 !important;     /* 줄 높이도 살짝 줄이기 */
-    display: inline-block;
-    max-width: 15ch;          /* 글자 10자 정도 */
-    white-space: nowrap;      /* 줄바꿈 금지 */
-    overflow: hidden;         /* 넘치는 건 숨김 */
-    text-overflow: ellipsis;  /* ... 으로 처리 */
-  }
-
-  .ExploreCard .MyFolderDesc {
-    font-size: 12px !important;
-    color: #777;
-    line-height: 1.2;
-    margin: 0 !important;
-
-    margin-top: 0px !important;        /* 설명 위쪽 간격 없애기 */
-    margin-bottom: 5px !important;
-    line-height: 1.0 !important;     /* 줄 높이도 맞춰주기 */
-    
-    display: inline-block;
-    max-width: 20ch;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  /* 하단 메타(아이콘/숫자) 한 줄 */
-  .ExploreCard .MyFolderStats {
-    display: flex !important;
-    gap: 12px;
-    margin-top: 6px;
-    font-size: 11px;
-    color: #555;
-    margin-top: 10px !important;
-  }
-
-  /* 필요 없으면 잠금 아이콘 숨김 */
-  .ExploreCard .MyFolderLock { 
-    display: none; 
+    /* ── 카드 본체를 가로 배치로 전환 ── */
+    .ExploreCard .MyFolderCard {
+        display: flex !important;
+        flex-direction: row !important;
+        align-items: center;
+        width: 94% !important;
+        height: 96px !important; /* 전체 높이(필요시 88~110px에서 조절) */
+        border-radius: 12px !important;
+        overflow: hidden !important;
+        box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
+        margin-left: auto;
+        margin-right: auto;
     }
 
-  /* 헤더(유저/시간) 여백만 살짝 줄이기 */
-  .UserFolderCardHeader { padding: 0 4px 6px 4px !important;}
-  .UserFolderCardAvatar { width: 28px; height: 28px; }
-  .UserFolderCardName   { font-size: 12px; }
-  .UserFolderCardCreateTime { font-size: 11px; }
-}
+    /* 왼쪽 썸네일(정사각) */
+    .ExploreCard .MyFolderImageContainer {
+        flex: 0 0 96px !important; /* 정사각 한 변 */
+        width: 96px !important;
+        height: 96px !important;
+        border-radius: 12px !important;
+        overflow: hidden;
+    }
 
+    .ExploreCard .MyFolderImage {
+        width: 90% !important;
+        height: 90% !important;
+        object-fit: cover; /* 꽉 채우기 */
+        border-radius: 5px 5px 5px 5px !important; /* 아래쪽만 둥글게 */
+    }
+
+    /* 오른쪽 정보영역 */
+    .ExploreCard .MyFolderInfo {
+        flex: 1 1 auto !important;
+        height: auto !important;
+        padding: 8px 12px !important;
+        background: transparent !important;
+        border-radius: 0 !important;
+    }
+
+    .ExploreCard .MyFolderTitle {
+        font-size: 14px !important;
+        font-weight: 700;
+        line-height: 1.2;
+        margin-bottom: 0px !important;
+
+        line-height: 1.1 !important; /* 줄 높이도 살짝 줄이기 */
+        display: inline-block;
+        max-width: 15ch; /* 글자 10자 정도 */
+        white-space: nowrap; /* 줄바꿈 금지 */
+        overflow: hidden; /* 넘치는 건 숨김 */
+        text-overflow: ellipsis; /* ... 으로 처리 */
+    }
+
+    .ExploreCard .MyFolderDesc {
+        font-size: 12px !important;
+        color: #777;
+        line-height: 1.2;
+        margin: 0 !important;
+
+        margin-top: 0px !important; /* 설명 위쪽 간격 없애기 */
+        margin-bottom: 5px !important;
+        line-height: 1 !important; /* 줄 높이도 맞춰주기 */
+
+        display: inline-block;
+        max-width: 20ch;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    /* 하단 메타(아이콘/숫자) 한 줄 */
+    .ExploreCard .MyFolderStats {
+        display: flex !important;
+        gap: 12px;
+        margin-top: 6px;
+        font-size: 11px;
+        color: #555;
+        margin-top: 10px !important;
+    }
+
+    /* 필요 없으면 잠금 아이콘 숨김 */
+    .ExploreCard .MyFolderLock {
+        display: none;
+    }
+
+    /* 헤더(유저/시간) 여백만 살짝 줄이기 */
+    .UserFolderCardHeader {
+        padding: 0 4px 6px 4px !important;
+    }
+    .UserFolderCardAvatar {
+        width: 28px;
+        height: 28px;
+    }
+    .UserFolderCardName {
+        font-size: 12px;
+    }
+    .UserFolderCardCreateTime {
+        font-size: 11px;
+    }
+}
 
 /* 모바일(~768, iPhone SE 포함) */
 /*
@@ -299,8 +307,6 @@
 }
 */
 
-
 /* 아주 작은 기기(~360) */
 @media (max-width: 360px) {
-
 }

--- a/src/features/main/styles/MyFoldersSection.css
+++ b/src/features/main/styles/MyFoldersSection.css
@@ -149,17 +149,23 @@
 /* 섹션 헤더 스타일 */
 .SectionHeader {
     display: flex;
-    justify-content: space-between;  /* 왼쪽 텍스트, 오른쪽 화살표 */
-    align-items: center;       
+    justify-content: space-between; /* 왼쪽 텍스트, 오른쪽 화살표 */
+    align-items: center;
     /* display: flex;
     align-items: center;
     gap: 10px; */
 }
 
+/* Explore 섹션과 동일한 중앙 래퍼 적용 */
+.ExploreInner {
+    width: min(100%, calc(4 * 320px + 3 * 24px));
+    margin: 0 auto;
+}
+
 .SectionTitle {
     font-size: 24px;
     font-weight: 600;
-    line-height: 1;      /* 화살표랑 동일하게 */
+    line-height: 1; /* 화살표랑 동일하게 */
     display: flex;
     align-items: center;
     /* font-size: 24px;
@@ -167,14 +173,14 @@
 }
 
 .SectionArrow {
-      margin-left: auto;   /* 왼쪽 영역을 밀어내서 끝으로 */
-  font-size: 24px;
-  font-weight: 600;
-  cursor: pointer;
-  color: #757575;
-  line-height: 1;      /* 텍스트 높이 맞추기 */
-  display: flex;       /* flex로 세로 중앙 정렬 */
-  align-items: center;
+    margin-left: auto; /* 왼쪽 영역을 밀어내서 끝으로 */
+    font-size: 24px;
+    font-weight: 600;
+    cursor: pointer;
+    color: #757575;
+    line-height: 1; /* 텍스트 높이 맞추기 */
+    display: flex; /* flex로 세로 중앙 정렬 */
+    align-items: center;
     /* font-size: 24px;
     font-weight: 600;
     margin: 0;
@@ -192,12 +198,10 @@
 /* 반응형 */
 
 @media (max-width: 1024px) {
-
 }
 
 /* 모바일(~768, iPhone SE 포함) */
 @media (max-width: 768px) {
-
     /* 각 폴더 사이즈 */
     .MyFoldersSection .MyFolderCard,
     .SharedFoldersSection .MyFolderCard {
@@ -220,12 +224,8 @@
         font-size: 18px;
         font-weight: 600;
     }
-
-
-    
 }
 
 /* 아주 작은 기기(~360) */
 @media (max-width: 360px) {
-
 }

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -5,8 +5,8 @@ import Header from '@/features/header/components/Header';
 import Layout from '@/components/layout/Layout';
 import { useAuthStore } from '@/stores/authStore';
 
-import MainPage from '@/pages/mainPage/MainPage';
-import LoginPage from '@/pages/loginPage/LoginPage';
+import MainPage from '@/pages/MainPage/MainPage';
+import LoginPage from '@/pages/LoginPage/LoginPage';
 import FollowerPage from '@/pages/FollowerPage/FollowerPage';
 import EditProfilePage from '@/pages/userPage/EditProfilePage';
 import StoragePage from '@/pages/storagePage/StoragePage';


### PR DESCRIPTION
### 완료사항

- ExploreSharedSection: .ExploreInner 래퍼 추가로 중앙 정렬/최대폭 관리
- MyFoldersSection: 동일 래퍼 적용으로 상단/하단 섹션 좌우 라인 일치
- ExploreGrid: max-width/margin 제거, 래퍼가 폭/정렬 책임지도록 변경
- useRecommendedFeed/useNoAuthMainFeed: enabled 플래그 도입
- ExploreSharedSection: 훅 조건부 호출 제거, safeLoadMore useCallback화, waitingRef로 재실행 방지
- 무한스크롤: waiting deps 제거로 타이머 클린업 충돌 해소