### PR TITLE
feature/#41 검색 오버레이 반응형 수정 및 몇 가지 버그 수정

### DIFF
--- a/src/features/search/components/RecentSearchPanel.jsx
+++ b/src/features/search/components/RecentSearchPanel.jsx
@@ -1,33 +1,52 @@
 import React from 'react';
 import styles from '../styles/RecentSearchPanel.module.css';
 
-const RecentSearchPanel = ({ recentSearches, onSearchClick, onRemoveSearch }) => {
+const RecentSearchPanel = ({ recentSearches, onSearchClick, onRemoveSearch, onClearAll }) => {
     return (
         <div className={styles.recentSearchPanel}>
-            <h3 className={styles.recentSearchTitle}>최근 검색</h3>
-            <ul className={styles.recentSearchList}>
-                {recentSearches.map((search, index) => (
-                    <li key={index} className={styles.recentSearchItem}>
-                        <div 
-                            className={styles.recentSearchText}
-                            onClick={() => onSearchClick(search)}
-                        >
-                            <span className={styles.recentSearchIcon}>🕐</span>
-                            <span className={styles.recentSearchTerm}>{search}</span>
-                        </div>
-                        <button 
-                            className={styles.recentSearchRemove}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                onRemoveSearch(search);
-                            }}
-                            aria-label="검색 기록 삭제"
-                        >
-                            ✕
-                        </button>
-                    </li>
-                ))}
-            </ul>
+            <div className={styles.recentSearchHeader}>
+                <h3 className={styles.recentSearchTitle}>최근 검색</h3>
+                {recentSearches.length > 0 && (
+                    <button 
+                        className={styles.clearAllButton}
+                        onClick={onClearAll}
+                        aria-label="모든 검색어 삭제"
+                    >
+                        전체 삭제
+                    </button>
+                )}
+            </div>
+            
+            {recentSearches.length > 0 ? (
+                <ul className={styles.recentSearchList}>
+                    {recentSearches.map((search, index) => (
+                        <li key={index} className={styles.recentSearchItem}>
+                            <div 
+                                className={styles.recentSearchText}
+                                onClick={() => onSearchClick(search)}
+                            >
+                                <span className={styles.recentSearchIcon}>🕐</span>
+                                <span className={styles.recentSearchTerm}>{search}</span>
+                            </div>
+                            <button 
+                                className={styles.recentSearchRemove}
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onRemoveSearch(search);
+                                }}
+                                aria-label="검색 기록 삭제"
+                            >
+                                ✕
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <div className={styles.emptyState}>
+                    <p className={styles.emptyStateText}>검색 기록이 없습니다</p>
+                    <p className={styles.emptyStateSubtext}>검색어를 입력하면 여기에 기록됩니다</p>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/features/search/components/SearchOverlay.jsx
+++ b/src/features/search/components/SearchOverlay.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { useSearchSuggestions } from '../hooks/useSearchSuggestions';
+import { useRecentSearches } from '../hooks/useRecentSearches';
 import { getRankings } from '../api/searchApi';
 import SearchHeader from './SearchHeader';
 import SearchResultSection from './SearchResultSection';
@@ -12,14 +13,10 @@ const SearchOverlay = ({ isVisible, onClose }) => {
     const [isSearching, setIsSearching] = useState(false);
     const [rankings, setRankings] = useState(null);
     const [rankingsLoading, setRankingsLoading] = useState(false);
-    const [recentSearches, setRecentSearches] = useState([
-        '부산여행',
-        '부산 가볼만한 맛집',
-        '제주도 가고싶다.'
-    ]);
     
     const navigate = useNavigate();
     const { suggestions, loading, error, fetchSuggestions } = useSearchSuggestions();
+    const { recentSearches, addSearchTerm, removeSearchTerm, clearAllSearches } = useRecentSearches();
 
     useEffect(() => {
         if (isVisible) {
@@ -36,13 +33,10 @@ const SearchOverlay = ({ isVisible, onClose }) => {
 
         if (isVisible) {
             document.addEventListener('keydown', handleKeyDown);
-            // 전체 페이지 스크롤을 막지 않도록 주석 처리
-            // document.body.style.overflow = 'hidden';
         }
 
         return () => {
             document.removeEventListener('keydown', handleKeyDown);
-            // document.body.style.overflow = 'unset';
         };
     }, [isVisible]);
 
@@ -78,9 +72,7 @@ const SearchOverlay = ({ isVisible, onClose }) => {
     const handleSearch = (searchTerm = query) => {
         if (searchTerm.trim()) {
             // 최근 검색어에 추가
-            if (!recentSearches.includes(searchTerm)) {
-                setRecentSearches(prev => [searchTerm, ...prev.slice(0, 2)]);
-            }
+            addSearchTerm(searchTerm);
             // 먼저 검색 오버레이를 닫고 페이지 이동
             handleClose();
             // 약간의 지연 후 페이지 이동하여 상태 업데이트가 완료되도록 함
@@ -101,12 +93,29 @@ const SearchOverlay = ({ isVisible, onClose }) => {
     };
 
     const handleRemoveSearch = (searchToRemove) => {
-        setRecentSearches(prev => prev.filter(item => item !== searchToRemove));
+        removeSearchTerm(searchToRemove);
     };
 
     const handlePreviewItemClick = (item) => {
-        // 해당 검색어 폴더 페이지로 이동
-        console.log('폴더 클릭:', item);
+        // 해당 폴더의 상세페이지로 이동
+        if (item && item.folderId) {
+            const targetUserIdParam = item.userId
+                ? `&targetUserId=${item.userId}`
+                : item.ownerUserId
+                  ? `&targetUserId=${item.ownerUserId}`
+                  : '';
+            
+            const url = `/folder/${item.folderId}?${targetUserIdParam}`;
+            console.log('폴더 상세페이지로 이동:', url);
+            
+            // 검색 오버레이 닫기
+            handleClose();
+            
+            // 페이지 이동
+            setTimeout(() => {
+                navigate({ to: url });
+            }, 100);
+        }
     };
 
     return (
@@ -119,14 +128,18 @@ const SearchOverlay = ({ isVisible, onClose }) => {
                     onSearch={handleSearch}
                 />
 
-                {!isSearching && (
+                {/* 검색 상태에 따른 조건부 렌더링 */}
+                {!isSearching ? (
+                    // 초기 상태: 최근 검색 + 랭킹
                     <>
                         <SearchResultSection 
                             recentSearches={recentSearches}
                             searchResults={[]}
                             searchLoading={false}
+                            isSearching={isSearching}
                             onSearchClick={handleSearchClick}
                             onRemoveSearch={handleRemoveSearch}
+                            onClearAll={clearAllSearches}
                             onPreviewItemClick={handlePreviewItemClick}
                         />
                         <SortedRankingSection 
@@ -134,15 +147,16 @@ const SearchOverlay = ({ isVisible, onClose }) => {
                             loading={rankingsLoading}
                         />
                     </>
-                )}
-
-                {isSearching && (
+                ) : (
+                    // 검색 중: 검색 결과만 표시
                     <SearchResultSection 
                         recentSearches={recentSearches}
                         searchResults={suggestions}
                         searchLoading={loading}
+                        isSearching={isSearching}
                         onSearchClick={handleSearchClick}
                         onRemoveSearch={handleRemoveSearch}
+                        onClearAll={clearAllSearches}
                         onPreviewItemClick={handlePreviewItemClick}
                     />
                 )}
@@ -151,4 +165,4 @@ const SearchOverlay = ({ isVisible, onClose }) => {
     );
 };
 
-export default SearchOverlay; 
+export default SearchOverlay;

--- a/src/features/search/components/SearchResultSection.jsx
+++ b/src/features/search/components/SearchResultSection.jsx
@@ -7,22 +7,30 @@ const SearchResultSection = ({
     recentSearches, 
     searchResults, 
     searchLoading, 
+    isSearching,
     onSearchClick, 
     onRemoveSearch, 
+    onClearAll,
     onPreviewItemClick 
 }) => {
     return (
         <div className={styles.searchResultSection}>
-            <RecentSearchPanel 
-                recentSearches={recentSearches}
-                onSearchClick={onSearchClick}
-                onRemoveSearch={onRemoveSearch}
-            />
-            <SearchPreviewList 
-                results={searchResults}
-                loading={searchLoading}
-                onItemClick={onPreviewItemClick}
-            />
+            {!isSearching ? (
+                // 초기 상태: 최근 검색만 표시
+                <RecentSearchPanel 
+                    recentSearches={recentSearches}
+                    onSearchClick={onSearchClick}
+                    onRemoveSearch={onRemoveSearch}
+                    onClearAll={onClearAll}
+                />
+            ) : (
+                // 검색 중: 검색 결과 프리뷰 표시
+                <SearchPreviewList 
+                    results={searchResults}
+                    loading={searchLoading}
+                    onItemClick={onPreviewItemClick}
+                />
+            )}
         </div>
     );
 };

--- a/src/features/search/hooks/useRecentSearches.js
+++ b/src/features/search/hooks/useRecentSearches.js
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const RECENT_SEARCHES_KEY = 'kkrap_recent_searches';
+const MAX_RECENT_SEARCHES = 10;
+
+export const useRecentSearches = () => {
+    const [recentSearches, setRecentSearches] = useState([]);
+
+    // 로컬 스토리지에서 최근 검색어 불러오기
+    const loadRecentSearches = useCallback(() => {
+        try {
+            const stored = localStorage.getItem(RECENT_SEARCHES_KEY);
+            if (stored) {
+                const parsed = JSON.parse(stored);
+                return Array.isArray(parsed) ? parsed : [];
+            }
+        } catch (error) {
+            console.error('최근 검색어 로드 오류:', error);
+        }
+        return [];
+    }, []);
+
+    // 로컬 스토리지에 최근 검색어 저장하기
+    const saveRecentSearches = useCallback((searches) => {
+        try {
+            localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches));
+        } catch (error) {
+            console.error('최근 검색어 저장 오류:', error);
+        }
+    }, []);
+
+    // 초기 로드
+    useEffect(() => {
+        const searches = loadRecentSearches();
+        setRecentSearches(searches);
+    }, [loadRecentSearches]);
+
+    // 검색어 추가
+    const addSearchTerm = useCallback((searchTerm) => {
+        if (!searchTerm.trim()) return;
+
+        setRecentSearches(prev => {
+            // 중복 제거
+            const filtered = prev.filter(term => term !== searchTerm);
+            // 새로운 검색어를 맨 앞에 추가
+            const newSearches = [searchTerm, ...filtered];
+            // 최대 개수 제한
+            const limited = newSearches.slice(0, MAX_RECENT_SEARCHES);
+            
+            // 로컬 스토리지에 저장
+            saveRecentSearches(limited);
+            
+            return limited;
+        });
+    }, [saveRecentSearches]);
+
+    // 검색어 제거
+    const removeSearchTerm = useCallback((searchTerm) => {
+        setRecentSearches(prev => {
+            const newSearches = prev.filter(term => term !== searchTerm);
+            saveRecentSearches(newSearches);
+            return newSearches;
+        });
+    }, [saveRecentSearches]);
+
+    // 모든 검색어 제거
+    const clearAllSearches = useCallback(() => {
+        setRecentSearches([]);
+        saveRecentSearches([]);
+    }, [saveRecentSearches]);
+
+    return {
+        recentSearches,
+        addSearchTerm,
+        removeSearchTerm,
+        clearAllSearches
+    };
+};

--- a/src/features/search/styles/RecentSearchPanel.module.css
+++ b/src/features/search/styles/RecentSearchPanel.module.css
@@ -2,16 +2,38 @@
     padding: 24px;
     background: white;
     border-right: 1px solid #e9ecef;
-    border-bottom: 1px solid #e9ecef; /* 아래쪽 스트로크 추가 */
     width: 300px;
     flex-shrink: 0;
+}
+
+.recentSearchHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
 }
 
 .recentSearchTitle {
     font-size: 1rem;
     font-weight: 700;
     color: #2d3748;
-    margin-bottom: 16px;
+    margin: 0;
+}
+
+.clearAllButton {
+    font-size: 0.8rem;
+    color: #6c757d;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: all 0.2s;
+}
+
+.clearAllButton:hover {
+    color: #dc3545;
+    background: #fef2f2;
 }
 
 .recentSearchList {
@@ -65,4 +87,22 @@
 .recentSearchRemove:hover {
     color: #dc3545;
     background: #fef2f2;
+}
+
+.emptyState {
+    text-align: center;
+    padding: 40px 20px;
+    color: #6c757d;
+}
+
+.emptyStateText {
+    font-size: 0.9rem;
+    font-weight: 500;
+    margin: 0 0 8px 0;
+}
+
+.emptyStateSubtext {
+    font-size: 0.8rem;
+    margin: 0;
+    line-height: 1.4;
 }

--- a/src/features/search/styles/SearchResultSection.module.css
+++ b/src/features/search/styles/SearchResultSection.module.css
@@ -3,4 +3,5 @@
     min-height: 400px;
     background: white;
     flex: 1;
+    border-bottom: 1px solid #e9ecef; /* 아래쪽 스트로크 추가 */
 }

--- a/src/features/search/styles/SortedResultsSection.module.css
+++ b/src/features/search/styles/SortedResultsSection.module.css
@@ -16,6 +16,7 @@
   border-bottom: 1px solid #e9ecef; /* 타이틀 아래 스트로크 추가 */
   border-top: 1px solid #e9ecef; /* 타이틀 위에 스트로크 추가 */
   padding-top: 20px; /* 위쪽 스트로크와 타이틀 사이 여백 */
+  line-height: 1.2; /* 일관된 줄 높이 */
 }
 
 /* 첫 번째 섹션(조회순)의 타이틀은 위쪽 스트로크 제거하고 패딩 조정 */
@@ -24,11 +25,13 @@
   padding-top: 8px; /* 첫 번째 섹션은 위쪽 패딩 조정 */
 }
 
-/* 스크랩순 타이틀의 크기를 조회순과 비슷하게 맞춤 */
+/* 스크랩순 타이틀의 크기를 조회순과 완전히 동일하게 맞춤 */
 .sortedSection:last-child .sortedTitle {
   font-size: 24px; /* 조회순과 동일한 폰트 크기 */
   font-weight: 700; /* 조회순과 동일한 폰트 굵기 */
   padding-top: 8px; /* 위쪽 패딩을 8px로 조정 */
+  line-height: 1.2; /* 조회순과 동일한 줄 높이 */
+  margin: 0 0 20px 0; /* 조회순과 동일한 마진 */
 }
 
 .sortedSection {
@@ -235,60 +238,217 @@
   }
 }
 
-@media (max-width: 768px) {
+/* 태블릿 반응형 스타일 */
+@media (max-width: 1024px) {
   .cardGridContainer {
-    max-width: 842px; /* 정확히 4개 카드가 보이도록 계산: (200px × 4) + (14px × 3) = 842px */
-    gap: 8px;
-  }
-
-  .scrollButton {
-    width: 35px;
-    height: 35px;
-    font-size: 18px;
+    max-width: 900px;
+    padding: 0 50px;
   }
 
   .cardGrid {
-    gap: 14px;
-    max-width: 842px;
-    padding: 0;
+    gap: 15px;
+    max-width: 800px;
   }
   
   .RankingCardGridItem {
-    width: 200px;
-    padding: 6px 0;
+    width: 220px;
   }
   
   .RankingCardGridItem :global(.MyFolderCard) {
-    max-width: 200px;
-    min-height: 250px;
+    max-width: 220px;
+    min-height: 280px;
   }
 }
 
-@media (max-width: 480px) {
-  .cardGridContainer {
-    max-width: 676px; /* 정확히 4개 카드가 보이도록 계산: (160px × 4) + (12px × 3) = 676px */
-    gap: 6px;
+/* 모바일 반응형 스타일 */
+@media (max-width: 768px) {
+  .sortedResultsSection {
+    padding: 0 16px 16px 16px;
   }
-
+  
+  .sortedTitle {
+    font-size: 20px;
+    margin: 0 0 16px 0;
+    padding: 16px 0 8px 0;
+    line-height: 1.2; /* 모바일에서도 일관된 줄 높이 */
+  }
+  
+  /* 모바일에서도 첫 번째와 마지막 섹션의 타이틀 크기 동일하게 */
+  .sortedSection:first-child .sortedTitle {
+    padding-top: 8px;
+    font-size: 20px;
+    line-height: 1.2;
+  }
+  
+  .sortedSection:last-child .sortedTitle {
+    padding-top: 8px;
+    font-size: 20px;
+    line-height: 1.2;
+    margin: 0 0 16px 0;
+  }
+  
+  .sortedSection {
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+  }
+  
+  /* 모바일에서 슬라이드 버튼 숨김 */
   .scrollButton {
-    width: 30px;
-    height: 30px;
-    font-size: 16px;
+    display: none !important;
+  }
+  
+  /* 모바일에서 컨테이너 최적화 */
+  .cardGridContainer {
+    margin: 0;
+    max-width: none !important;
+    padding: 0 !important;
+    width: 100% !important;
+  }
+  
+  /* 모바일에서 카드 그리드 조정 - 가로 스크롤 유지 */
+  .cardGrid {
+    display: flex !important;
+    flex-wrap: nowrap !important;
+    gap: 12px !important;
+    padding: 8px 0 !important; /* 위아래 패딩 추가로 카드 잘림 방지 */
+    overflow-x: auto !important; /* 가로 스크롤 유지 */
+    scroll-behavior: smooth !important;
+    width: 100% !important;
+    max-width: none !important;
+    justify-content: flex-start !important; /* 왼쪽 정렬로 변경 */
+  }
+  
+  /* 모바일에서 카드 크기 조정 - 3개가 보이도록 */
+  .RankingCardGridItem {
+    flex-shrink: 0 !important; /* 카드가 줄어들지 않도록 */
+    min-width: calc((100vw - 32px - 24px) / 3) !important; /* 화면 너비 - 패딩 - 간격 */
+    max-width: calc((100vw - 32px - 24px) / 3) !important;
+    width: calc((100vw - 32px - 24px) / 3) !important;
+    padding: 4px 0 !important; /* 위아래 패딩 추가 */
+  }
+  
+  /* 모바일에서 MyFolderCard 스타일 조정 */
+  .RankingCardGridItem :global(.MyFolderCard) {
+    width: 100% !important;
+    height: auto !important;
+    min-height: 120px !important; /* 높이를 늘려서 썸네일이 더 크게 보이도록 */
+    max-height: 140px !important;
+  }
+  
+  /* 모바일에서 썸네일 컨테이너를 더 크게 */
+  .RankingCardGridItem :global(.MyFolderImageContainer) {
+    width: 100% !important;
+    height: 70px !important; /* 썸네일 영역을 더 크게 */
+    min-width: 100% !important;
+    flex: 1 !important; /* 남은 공간을 모두 차지하도록 */
+  }
+  
+  /* 모바일에서 썸네일 이미지를 더 크게 */
+  .RankingCardGridItem :global(.MyFolderImage) {
+    width: 90% !important; /* 썸네일 너비를 더 크게 */
+    height: 100% !important;
+    object-fit: cover !important;
+  }
+  
+  /* 모바일에서 멀티 썸네일 그리드도 더 크게 */
+  .RankingCardGridItem :global(.MultiThumbnailGrid) {
+    width: 90% !important;
+    height: 100% !important;
+  }
+  
+  .RankingCardGridItem :global(.MyFolderInfo) {
+    padding: 8px !important;
+    flex: 0 0 auto !important; /* 정보 영역은 고정 크기 */
+  }
+  
+  .RankingCardGridItem :global(.MyFolderTitle) {
+    font-size: 13px !important;
+    line-height: 1.2 !important;
+    margin-bottom: 4px !important;
+  }
+  
+  /* 모바일에서 폴더 설명(소개) 숨김 */
+  .RankingCardGridItem :global(.MyFolderDesc) {
+    display: none !important;
+  }
+  
+  .RankingCardGridItem :global(.MyFolderStats) {
+    font-size: 10px !important;
+    gap: 6px !important;
+  }
+}
+
+/* 작은 모바일 반응형 스타일 */
+@media (max-width: 480px) {
+  .sortedTitle {
+    font-size: 18px; /* 작은 모바일에서 타이틀 크기 조정 */
+    line-height: 1.2;
+  }
+  
+  /* 작은 모바일에서도 첫 번째와 마지막 섹션의 타이틀 크기 동일하게 */
+  .sortedSection:first-child .sortedTitle {
+    padding-top: 8px;
+    font-size: 18px;
+    line-height: 1.2;
+  }
+  
+  .sortedSection:last-child .sortedTitle {
+    padding-top: 8px;
+    font-size: 18px;
+    line-height: 1.2;
+    margin: 0 0 16px 0;
+  }
+  
+  .cardGridContainer {
+    max-width: none !important;
+    padding: 0 !important;
+    width: 100% !important;
   }
 
   .cardGrid {
-    gap: 12px;
-    max-width: 676px;
-    padding: 0;
+    gap: 8px !important;
+    padding: 0 !important;
   }
   
   .RankingCardGridItem {
-    width: 160px;
-    padding: 5px 0;
+    min-width: calc((100vw - 32px - 16px) / 3) !important; /* 간격 줄임 */
+    max-width: calc((100vw - 32px - 16px) / 3) !important;
+    width: calc((100vw - 32px - 16px) / 3) !important;
   }
   
   .RankingCardGridItem :global(.MyFolderCard) {
-    max-width: 160px;
-    min-height: 200px;
+    min-height: 110px !important; /* 작은 모바일에서도 썸네일이 크게 보이도록 */
+    max-height: 130px !important;
+  }
+  
+  .RankingCardGridItem :global(.MyFolderImageContainer) {
+    width: 100% !important;
+    height: 65px !important; /* 작은 모바일에서도 썸네일 영역 유지 */
+    min-width: 100% !important;
+    flex: 1 !important;
+  }
+  
+  .RankingCardGridItem :global(.MyFolderImage) {
+    width: 90% !important;
+    height: 100% !important;
+  }
+  
+  .RankingCardGridItem :global(.MultiThumbnailGrid) {
+    width: 90% !important;
+    height: 100% !important;
+  }
+  
+  .RankingCardGridItem :global(.MyFolderTitle) {
+    font-size: 12px !important;
+  }
+  
+  /* 작은 모바일에서도 폴더 설명(소개) 숨김 */
+  .RankingCardGridItem :global(.MyFolderDesc) {
+    display: none !important;
+  }
+  
+  .RankingCardGridItem :global(.MyFolderStats) {
+    font-size: 9px !important;
+    gap: 4px !important;
   }
 }

--- a/src/pages/FollowerPage/FollowerPage.module.css
+++ b/src/pages/FollowerPage/FollowerPage.module.css
@@ -104,12 +104,27 @@
 /* 반응형 디자인 */
 @media (max-width: 1024px) {
   .sidebar {
-    width: 240px;
-    min-width: 240px;
+    transform: translateX(-100%);
+  }
+  
+  .sidebar.open {
+    transform: translateX(0);
   }
   
   .contentWrapper {
-    margin-left: 240px;
+    margin-left: 0;
+  }
+  
+  /* 1024px 이하에서는 오버레이 숨김 (768px 이하에서만 표시) */
+  .mobileSidebarOverlay {
+    display: none;
+  }
+}
+
+/* 769px 이상에서 팔로잉 목록 버튼 숨김 */
+@media (min-width: 769px) {
+  .followingListButton {
+    display: none;
   }
 }
 
@@ -128,6 +143,7 @@
     margin-left: 0;
   }
   
+  /* 768px 이하에서만 오버레이 표시 */
   .mobileSidebarOverlay {
     display: block;
   }

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -6,6 +6,7 @@ import './SearchPage.css';
 const SearchPage = () => {
     const { results, loading, error, searchTerm, refetchResults } = useSearchPage();
 
+
     if (!searchTerm) {
         return (
             <div className="search-page">
@@ -58,27 +59,35 @@ const SearchPage = () => {
 
                 {!loading && !error && results.length > 0 && (
                     <div className="search-results-grid">
-                        {results.map((result, index) => (
-                            <div key={result.folderId || result.id || index} className="search-result-card">
-                                <MyFolderCard
-                                    folder={{
-                                        folderId: result.folderId || result.id || `search-${index}`,
-                                        folderName: result.folderName || result.title || `폴더 ${index + 1}`,
-                                        folderDescription: result.folderDescription || result.description || '설명이 없습니다.',
-                                        links: result.imageUrl ? [{ thumbnailUrl: result.imageUrl }] : 
-                                               result.thumbnailUrl ? [{ thumbnailUrl: result.thumbnailUrl }] :
-                                               result.faviconUrl ? [{ faviconUrl: result.faviconUrl }] : [],
-                                        scrapCount: result.scrapCount || 0,
-                                        viewCount: result.viewCount || 0,
-                                        visible: true
-                                    }}
-                                    onDelete={() => {}}
-                                    onEdit={() => {}}
-                                    onPermission={() => {}}
-                                    showMenu={false}
-                                />
-                            </div>
-                        ))}
+                        {results.map((result, index) => {
+                            const folderData = {
+                                folderId: result.folderId || result.id || `search-${index}`,
+                                folderName: result.folderName || result.title || `폴더 ${index + 1}`,
+                                folderDescription: result.folderDescription || result.description || '설명이 없습니다.',
+                                links: result.imageUrl ? [{ thumbnailUrl: result.imageUrl }] : 
+                                       result.thumbnailUrl ? [{ thumbnailUrl: result.thumbnailUrl }] :
+                                       result.faviconUrl ? [{ faviconUrl: result.faviconUrl }] : [],
+                                scrapCount: result.scrapCount || 0,
+                                viewCount: result.viewCount || 0,
+                                visible: true,
+                                userId: result.userId || result.ownerUserId,
+                                ownerUserId: result.ownerUserId || result.userId
+                            };
+                            
+                            console.log(`폴더 ${index} 데이터:`, folderData);
+                            
+                            return (
+                                <div key={result.folderId || result.id || index} className="search-result-card">
+                                    <MyFolderCard
+                                        folder={folderData}
+                                        onDelete={() => {}}
+                                        onEdit={() => {}}
+                                        onPermission={() => {}}
+                                        showMenu={false}
+                                    />
+                                </div>
+                            );
+                        })}
                     </div>
                 )}
 

--- a/src/pages/storageFolderDetail/StorageFolderDetail.jsx
+++ b/src/pages/storageFolderDetail/StorageFolderDetail.jsx
@@ -131,9 +131,8 @@ export default function StorageFolderDetail() {
                 onOpenPermission={() => openPermissionModal({ folderId, folderName: folderInfo?.folderName })}
             />
 
-]
             {/* Create 버튼 (링크 추가만) - 회원일 때만 표시 */}
-            {user && <CreateDropdown showFolderCreate={false} onSuccess={refetch} />}
+            {user && <CreateModal showFolderCreate={false} onSuccess={refetch} />}
             
             {/* 권한 모달 - 회원일 때만 표시 */}
             {user && showPermissionModal && (


### PR DESCRIPTION
# feat 
- 검색 오버레이에 반응형 적용했습니다.
- 랭킹 카드들이 768 이하 해상도에서 더이상 소개 부분이 나오지 않도록 수정했습니다.
- 검색 오버레이에서 최근 검색 섹션이 이제 로컬 스토리지에 저장되며 불러오는 방식으로 변경되었습니다.

# fix 
- 검색 오버레이에서 검색 프리뷰를 눌렀을때 상세 페이지로 이동되지 않던 버그를 수정했습니다.
- 검색 페이지에서 폴더를 눌렀을때 상세 페이지로의 이동은 되지만  targetId가 없어서 페이지 랜더링이 안되던 버그를 수정했습니다.

# chore
- 팔로우 페이지에서 팔로우 목록 보기 버튼이 768px 해상도 이상에서는 보이지 않도록 적용했습니다.