### PR TITLE
fix : 모바일에서 폴더 케밥 메뉴 버튼 크기/잘림 이슈 해결 및 모바일에서 폴더, 링크 생성 시 목록 갱신 안되던 이슈 해결

### DIFF
--- a/src/features/create/api/createApi.js
+++ b/src/features/create/api/createApi.js
@@ -5,10 +5,14 @@ const url = import.meta.env.VITE_URL;
 // 폴더 생성
 export async function createMyFolder(data) {
     console.log('api요청부분입니다이 ', data);
-    await api.post(`${url}/folders/users/folders`, data);
+    const res = await api.post(`${url}/folders/users/folders`, data);
+    console.log('createMyFolder 응답 데이터:', res?.data);
+    return res.data;
 }
 
 export async function createLink(data) {
     console.log('링크 생성 api요청부분입니다이 ', data);
-    await api.post(`${url}/links/users/links`, data);
+    const res = await api.post(`${url}/links/users/links`, data);
+    console.log('createLink 응답 데이터:', res?.data);
+    return res.data;
 }

--- a/src/features/create/components/LinkAddModal.jsx
+++ b/src/features/create/components/LinkAddModal.jsx
@@ -14,11 +14,6 @@ export default function LinkAddModal({ onClose, onSubmit, folders = [], linkSubm
     const [link, setLink] = useState('');
     const [selectedFolder, setSelectedFolder] = useState(currentFolder?.folderId || folders[0]?.folderId || '');
 
-    console.log('folderId', folderId);
-    console.log('currentFolder', currentFolder);
-    console.log('folders@@@@@@@@@@@@@@@@@@@@@@@@@@@@@', folders);
-    console.log('folders[0].folderId:', folders[0]?.folderId, typeof folders[0]?.folderId);
-
     const handlePaste = async () => {
         try {
             const text = await navigator.clipboard.readText();

--- a/src/features/create/hooks/useCreate.js
+++ b/src/features/create/hooks/useCreate.js
@@ -40,9 +40,9 @@ export default function useCreate(initialFolders = [], userId, onSuccess) {
         if (creatingFolder) return;
         setCreatingFolder(true);
         try {
-            await createMyFolder(data, userId);
+            const created = await createMyFolder(data, userId);
             setShowFolderModal(false);
-            if (onSuccess) onSuccess();
+            if (onSuccess) onSuccess(created);
         } catch (err) {
             console.error('폴더 create 안됨 :', err);
         } finally {
@@ -60,9 +60,10 @@ export default function useCreate(initialFolders = [], userId, onSuccess) {
                 linkUrl: link,
                 foldersId: Number(folderId),
             };
-            await createLink(linkData, userId);
+            const created = await createLink(linkData, userId);
             setShowLinkModal(false);
-            if (onSuccess) onSuccess();
+            console.log('[useCreate] onSuccess 전달할 createdLink:', created);
+            if (onSuccess) onSuccess(created);
         } catch (err) {
             console.error('링크 create 안됨 :', err);
         } finally {

--- a/src/features/folderDetail/styles/LinkList.css
+++ b/src/features/folderDetail/styles/LinkList.css
@@ -45,7 +45,7 @@
 /* 반응형 조정 */
 @media (max-width: 768px) {
     .LinkGrid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 16px;
     }
 

--- a/src/features/header/components/NavMenu.jsx
+++ b/src/features/header/components/NavMenu.jsx
@@ -43,7 +43,26 @@ export default function NavMenu({ toggleSearch, showSearchInput }) {
             {/* 모바일에서만 중앙 Create 버튼 */}
             {isMobile && (
                 <div className="NavItem Create">
-                    <CreateModal showFolderCreate onSuccess={undefined} />
+                    <CreateModal
+                        showFolderCreate
+                        onSuccess={(created) => {
+                            try {
+                                if (created && typeof created === 'object') {
+                                    if ('foldersId' in created) {
+                                        window.dispatchEvent(
+                                            new CustomEvent('links:refresh', {
+                                                detail: { folderId: created.foldersId, createdLink: created },
+                                            })
+                                        );
+                                    } else if ('folderId' in created) {
+                                        window.dispatchEvent(
+                                            new CustomEvent('folders:refresh', { detail: { createdFolder: created } })
+                                        );
+                                    }
+                                }
+                            } catch (_) {}
+                        }}
+                    />
                 </div>
             )}
 

--- a/src/features/main/components/MyFoldersSection.jsx
+++ b/src/features/main/components/MyFoldersSection.jsx
@@ -10,6 +10,12 @@ const MyFoldersSection = () => {
     const navigate = useNavigate();
     const userId = user?.userId;
     const { ownFolders = [], sharedFolders = [] } = useMyFolder(userId) || {};
+    const surveyUrl = import.meta.env.VITE_SURVEY_URL;
+    const isLoggedIn = !!user;
+
+    const handleSurveyClick = () => {
+        window.open(surveyUrl, '_blank');
+    };
 
     // 전체 폴더 배열 생성 (own + shared)
     const allFolders = [
@@ -53,6 +59,14 @@ const MyFoldersSection = () => {
             {/* 나의 폴더 섹션 */}
             <div className="MyFoldersSection">
                 <div className="ExploreInner">
+                    {/* 설문조사 버튼 - 로그인 상태에 따라 다르게 표시 */}
+                    {isLoggedIn && (
+                        <div className="MainPageHeader">
+                            <button className="MainPageHeaderButton" onClick={handleSurveyClick}>
+                                설문조사하고 커피 받기
+                            </button>
+                        </div>
+                    )}
                     <div className="SectionHeader">
                         <h2 className="SectionTitle">{user ? `${user.nickname}님의 폴더` : '나의 폴더'}</h2>
                         <span className="SectionArrow" onClick={() => navigate({ to: `/storage/${userId}` })}>

--- a/src/features/main/styles/MyFoldersSection.css
+++ b/src/features/main/styles/MyFoldersSection.css
@@ -149,11 +149,7 @@
 /* 섹션 헤더 스타일 */
 .SectionHeader {
     display: flex;
-    justify-content: space-between; /* 왼쪽 텍스트, 오른쪽 화살표 */
     align-items: center;
-    /* display: flex;
-    align-items: center;
-    gap: 10px; */
 }
 
 /* Explore 섹션과 동일한 중앙 래퍼 적용 */
@@ -173,7 +169,7 @@
 }
 
 .SectionArrow {
-    margin-left: auto; /* 왼쪽 영역을 밀어내서 끝으로 */
+    margin-left: 1rem;
     font-size: 24px;
     font-weight: 600;
     cursor: pointer;

--- a/src/features/storage/hooks/useMyFolder.js
+++ b/src/features/storage/hooks/useMyFolder.js
@@ -89,6 +89,9 @@ export default function useMyFolders(userId) {
         // 비회원일 때는 API 호출하지 않음
         if (!userId) return;
         fetchFolders();
+        // 디버깅: 리스트 길이 확인
+        // eslint-disable-next-line no-console
+        console.log('[useMyFolder] ownFolders len', ownFolders.length, 'shared len', sharedFolders.length);
     }, [fetchFolders, userId]);
 
     return { ownFolders, sharedFolders, removeFolder, fetchFolders, myFolderProfile, editFolder };

--- a/src/features/storage/styles/MyFolderCard.css
+++ b/src/features/storage/styles/MyFolderCard.css
@@ -214,15 +214,58 @@
 }
 
 @media (max-width: 1024px) {
-
 }
 
-/* 모바일(~768, iPhone SE 포함) */
+/* 모바일(~768px) */
 @media (max-width: 768px) {
+    .FolderMenu {
+        width: 90%;
 
+        max-width: 260px;
+        border-radius: 14px;
+    }
+    .FolderMenuItem {
+        font-size: 16px;
+        padding: 12px 14px;
+        gap: 8px;
+    }
+    .FolderMenuIcon {
+        width: 24px;
+        height: 24px;
+        margin-right: 8px;
+    }
+}
+
+@media (max-width: 425px) {
+    .FolderMenu {
+        width: 90%;
+
+        max-width: 260px;
+        border-radius: 14px;
+    }
+    .FolderMenuItem {
+        font-size: 12px;
+        padding: 12px 14px;
+        gap: 8px;
+    }
+    .FolderMenuIcon {
+        width: 22px;
+        height: 22px;
+        margin-right: 8px;
+    }
 }
 
 /* 아주 작은 기기(~360) */
 @media (max-width: 360px) {
-
+    .FolderMenu {
+        max-width: 240px;
+    }
+    .FolderMenuItem {
+        font-size: 10px;
+        padding: 10px 12px;
+    }
+    .FolderMenuIcon {
+        width: 20px;
+        height: 20px;
+    }
 }

--- a/src/features/storage/styles/MyFolderList.css
+++ b/src/features/storage/styles/MyFolderList.css
@@ -1,15 +1,16 @@
 .FolderList {
     display: grid;
+    gap: 40px 32px; /* 행/열 간격 */
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 20px;
-    width: 100%;
-    margin: 0 auto;
+    /* 4열 기준 컨테이너 폭 제한 → 크게 봐도 4개까지만 */
+    width: min(100%, calc(4 * 320px + 3 * 24px));
+    margin: 0 auto; /* 중앙 정렬 */
 }
 
 /* 반응형 조정 */
 @media (max-width: 768px) {
     .FolderList {
-        grid-template-columns: 1fr;
-        gap: 16px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
     }
 }

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -5,25 +5,11 @@ import ExploreSharedSection from '@/features/main/components/ExploreSharedSectio
 import { useAuthStore } from '@/stores/authStore';
 
 function MainPage() {
-    const surveyUrl = import.meta.env.VITE_SURVEY_URL;
     const { user } = useAuthStore();
     const isLoggedIn = !!user;
 
-    const handleSurveyClick = () => {
-        window.open(surveyUrl, '_blank');
-    };
-
     return (
         <div className="MainPage">
-            {/* 설문조사 버튼 - 로그인 상태에 따라 다르게 표시 */}
-            {isLoggedIn && (
-                <div className="MainPageHeader">
-                    <button className="MainPageHeaderButton" onClick={handleSurveyClick}>
-                        설문조사하고 커피 받기
-                    </button>
-                </div>
-            )}
-
             {/* 나의 폴더 섹션 - 회원만 표시 */}
             <MyFoldersSection />
 

--- a/src/pages/storageFolderDetail/StorageFolderDetail.jsx
+++ b/src/pages/storageFolderDetail/StorageFolderDetail.jsx
@@ -88,6 +88,19 @@ export default function StorageFolderDetail() {
         handlePermissionRevoke,
     } = permissionHook;
 
+    // 모바일 하단 네비의 CreateModal에서 링크 생성 시 목록 갱신 이벤트 수신
+    React.useEffect(() => {
+        const handler = (e) => {
+            const detail = e?.detail;
+            const eventFolderId = detail?.folderId;
+            if (!eventFolderId) return;
+            if (String(eventFolderId) !== String(folderId)) return;
+            refetch();
+        };
+        window.addEventListener('links:refresh', handler);
+        return () => window.removeEventListener('links:refresh', handler);
+    }, [folderId, refetch]);
+
     if (loading) {
         return (
             <div style={{ textAlign: 'center' }}>
@@ -117,10 +130,15 @@ export default function StorageFolderDetail() {
                 onOpenPermission={() => openPermissionModal({ folderId, folderName: folderInfo?.folderName })}
             />
 
-
             {/* Create 버튼 (링크 추가만) - 회원일 때만 표시 */}
-            {user && <CreateModal showFolderCreate={false} onSuccess={refetch} />}
-            
+            {user && (
+                <CreateModal
+                    showFolderCreate={false}
+                    onSuccess={(createdLink) => {
+                        refetch();
+                    }}
+                />
+            )}
 
             {/* 권한 모달 - 회원일 때만 표시 */}
             {user && showPermissionModal && (

--- a/src/pages/storagePage/StoragePage.jsx
+++ b/src/pages/storagePage/StoragePage.jsx
@@ -10,6 +10,7 @@ import CreateModal from '@/features/create/components/CreateModal';
 import FolderCreateModal from '@/features/create/components/FolderCreateModal';
 import PermissionModal from '@/features/storage/components/PermissionModal';
 import usePermissionUsers from '@/features/storage/hooks/usePermissionUsers';
+import { useEffect } from 'react';
 
 const routeApi = getRouteApi('/storage/$userId');
 
@@ -31,7 +32,6 @@ export default function StoragePage() {
         myFolderProfile,
         editFolder,
     } = useMyFolder(targetUserId) || {};
-    console.log('째 : ', sharedFolders);
 
     // 모든 폴더를 하나의 배열로 합치기
     const allFolders = [
@@ -59,6 +59,15 @@ export default function StoragePage() {
 
     const [modalMode, setModalMode] = useState(null);
     const [editTargetFolder, setEditTargetFolder] = useState(null);
+
+    // 모바일 하단 Create에서 발생하는 생성 이벤트를 수신해 목록 갱신
+    useEffect(() => {
+        const handler = (e) => {
+            fetchFolders();
+        };
+        window.addEventListener('folders:refresh', handler);
+        return () => window.removeEventListener('folders:refresh', handler);
+    }, [fetchFolders]);
 
     // 폴더 수정 버튼 클릭 (MyFolderCard에서 호출)
     const handleEditClick = (folder) => {
@@ -94,12 +103,25 @@ export default function StoragePage() {
         await removeFolder(folder);
     };
 
+    // 제목에 사용할 표시 이름 결정
+    const displayOwnerName = isOwnStorage ? user?.nickname : myFolderProfile?.nickname;
+
     return (
         <div className="StorageContainer" style={{ paddingBottom: '120px' }}>
             <FolderHeader data={myFolderProfile} />
-            <div className="StorageHeader">
-                <h2 className="StorageTitle">{isOwnStorage ? `${user.nickname}님의 폴더` : `사용자의 폴더`}</h2>
-                {isOwnStorage && <CreateModal showFolderCreate onSuccess={fetchFolders} />}
+            <div className="ExploreInner">
+                <div className="StorageHeader">
+                    <h2 className="StorageTitle">{`${displayOwnerName || '사용자'}님의 폴더`}</h2>
+                    {isOwnStorage && (
+                        <CreateModal
+                            showFolderCreate
+                            onSuccess={(createdFolder) => {
+                                console.log('[StoragePage] onSuccess 수신 createdFolder:', createdFolder);
+                                fetchFolders();
+                            }}
+                        />
+                    )}
+                </div>
             </div>
             <FolderList
                 folders={ownFolders}
@@ -112,17 +134,19 @@ export default function StoragePage() {
             />
             {isOwnStorage && (
                 <>
-                    <div className="StorageHeader">
-                        <br />
-                        <h2 className="StorageTitle">{user.nickname}님과 공유된 폴더</h2>
-                        <FolderList
-                            folders={sharedFolders}
-                            onDelete={handleDelete}
-                            onEdit={handleEditClick}
-                            onPermission={openPermissionModal}
-                            allFolders={allFolders}
-                            showLockIcon={isOwnStorage}
-                        />
+                    <div className="ExploreInner">
+                        <div className="StorageHeader">
+                            <br />
+                            <h2 className="StorageTitle">{user.nickname}님과 공유된 폴더</h2>
+                            <FolderList
+                                folders={sharedFolders}
+                                onDelete={handleDelete}
+                                onEdit={handleEditClick}
+                                onPermission={openPermissionModal}
+                                allFolders={allFolders}
+                                showLockIcon={isOwnStorage}
+                            />
+                        </div>
                     </div>
                 </>
             )}


### PR DESCRIPTION
### 완료사항

- MyFolderCard 메뉴에 반응형 크기 조정(≤768/425/360px) 적용
- 폰트/아이콘/패딩 축소로 오버플로우 방지
- 상세 폴더·내 페이지에서 생성 후 목록 즉시 갱신(이벤트 연동 포함)
- Nav 모바일 CreateModal → folders:refresh / links:refresh 이벤트 생성
- StoragePage/StorageFolderDetail에서 이벤트 수신 후 fetch/refetch 처리